### PR TITLE
test: add SRFI 1 spec examples for multi-list fold and fold-right

### DIFF
--- a/tests/goldfish/liii/list-test.scm
+++ b/tests/goldfish/liii/list-test.scm
@@ -1245,6 +1245,14 @@ wrong-type-arg 当任何参数不是列表类型时可能抛出
 (check (fold list '() '(1 2 3) '(a b c)) => '(3 c (2 b (1 a ()))))
 (check-catch 'type-error (fold 0 + '(1 2 3) 'a))
 
+;;; SRFI 1 spec examples for multi-list fold
+(check (fold cons* '() '(a b c) '(1 2 3 4 5)) => '(c 3 b 2 a 1))
+
+;;; Additional multi-list fold tests
+(check (fold + 0 '(1 2 3) '(4 5 6) '(7 8 9)) => 45) ; three lists
+(check (fold cons* '() '(a) '(1)) => '(a 1))         ; single-element lists
+(check (fold + 0 '() '(1 2 3)) => 0)                  ; empty list terminates immediately
+
 (check (fold-right + 0 '(1 2 3 4)) => 10)
 
 (check (fold-right + 0 '()) => 0)
@@ -1262,6 +1270,14 @@ wrong-type-arg 当任何参数不是列表类型时可能抛出
 (check (fold-right + 0 '(1 2 3 4) '(10 20 30)) => 66)
 (check (fold-right list '() '(1 2 3) '(a b c)) => '(1 a (2 b (3 c ()))))
 (check-catch 'type-error (fold-right 0 + '(1 2 3) 'a))
+
+;;; SRFI 1 spec examples for multi-list fold-right
+(check (fold-right cons* '() '(a b c) '(1 2 3 4 5)) => '(a 1 b 2 c 3))
+
+;;; Additional multi-list fold-right tests
+(check (fold-right + 0 '(1 2 3) '(4 5 6) '(7 8 9)) => 45) ; three lists
+(check (fold-right cons* '() '(a) '(1)) => '(a 1))         ; single-element lists
+(check (fold-right + 0 '() '(1 2 3)) => 0)                  ; empty list terminates immediately
 
 (check (reduce + 0 '(1 2 3 4)) => 10)
 (check (reduce + 0 '()) => 0)


### PR DESCRIPTION
Closes https://github.com/MoganLab/goldfish/issues/190

What is the issue?
Issue https://github.com/MoganLab/goldfish/issues/190 reported that fold and fold-right should accept a variable number of lists per the SRFI 1 specification.

What was found?
The multi-list support for fold and fold-right has already been implemented in the current codebase (the definitions use rest args . lists and handle both single and multi-list cases). The issue referenced an older commit (https://github.com/MoganLab/goldfish/commit/43bb07199777f786456e997983958102960e6be7) where this was not yet the case.

What was changed?
Added the canonical SRFI 1 spec examples and additional edge-case tests to
tests/goldfish/liii/list-test.scm:

(fold cons* '() '(a b c) '(1 2 3 4 5)) — SRFI 1 spec example
(fold-right cons* '() '(a b c) '(1 2 3 4 5)) — SRFI 1 spec example
Three-list fold, single-element lists, and empty-list edge cases

<img width="1065" height="75" alt="554777423-dfd1ee4a-da27-43d0-960b-7e1074cffe5e" src="https://github.com/user-attachments/assets/9bc4956f-e081-4a5c-84ad-1fd82bf56974" />
