### PR TITLE
[0139] 修复 Windows 平台 subprocess 管道捕获失败问题

### DIFF
--- a/devel/0139.md
+++ b/devel/0139.md
@@ -1,0 +1,31 @@
+# [0139] 修复 Windows 平台 subprocess 管道捕获导致 gf pr / run-values 失败的问题
+
+## 任务相关的代码文件
+- src/liii_subprocess.cpp
+- tests/liii/subprocess/run-values-test.scm
+- tests/liii/subprocess/run-pipe-test.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/subprocess/run-values-test.scm
+bin/gf tests/liii/subprocess/run-pipe-test.scm
+bin/gf test tools/pr/tests/liii/goldpr/parse-pr-args-test.scm
+bin/gf test tools/pr/tests/liii/goldpr/pr-remote-url-test.scm
+```
+
+## 2026-08-31 修复 Windows 下 subprocess 管道捕获
+
+### What
+1. 修复 Windows 平台上 `(liii subprocess)` 在执行管道重定向（`:stdout 'capture`、`:stderr 'capture`、`:input`、`run-pipe`）时无法正确捕获输出甚至报错的问题。
+2. 修复 `gf pr` 在 Windows 下因 `pr-remote-url` 无法捕获 git 输出而误报 `Error: no origin remote found in this repository` 的问题。
+3. 补全并在 Windows 下启用 `run-values-test.scm` 和 `run-pipe-test.scm` 的捕获与管道断言测试。
+
+### Why
+在 Windows 平台上，tbox 的 `tb_pipe_file_init_pair` 内部通过带有 `FILE_FLAG_OVERLAPPED` 标志的具名管道实现异步 I/O。当子进程（如 Git、Python 或标准 C 运行时程序）继承该句柄并使用同步 `WriteFile` 写入时，Windows API 会返回 `ERROR_INVALID_PARAMETER` (Errno 22)，导致写入失败、输出捕获为空字符串。
+
+### How
+1. 在 Windows 平台（`_WIN32`）下，使用原生 Win32 API `CreatePipe` 创建同步管道，句柄传递给子进程的 `attr.out.file` / `attr.err.file` / `attr.in.file` 并标记继承。
+2. 父进程在启动子进程后关闭管道的写端/读端无用句柄，避免阻塞 EOF。
+3. 父进程使用同步 `ReadFile` 循环读取子进程管道输出直至 EOF，正确填充 `stdout_str` / `stderr_str`。
+4. 更新 `tests/liii/subprocess/run-values-test.scm` 与 `run-pipe-test.scm`，加入 Windows 平台的管道捕获与串联管道验证。

--- a/src/liii_subprocess.cpp
+++ b/src/liii_subprocess.cpp
@@ -21,6 +21,10 @@
 #include <tbox/tbox.h>
 #include <vector>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__EMSCRIPTEN__)
 #include <wordexp.h>
 #endif
@@ -180,7 +184,15 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
       (stdout_mode == redirect_mode::tee || stdout_mode == redirect_mode::capture) ||
       (stderr_to_stdout && stdout_mode != redirect_mode::file && stdout_mode != redirect_mode::discard);
 
+#ifdef _WIN32
+  HANDLE              h_out_read= NULL, h_out_write= NULL;
+  HANDLE              h_err_read= NULL, h_err_write= NULL;
+  HANDLE              h_in_read= NULL, h_in_write= NULL;
+  SECURITY_ATTRIBUTES sa= {sizeof (SECURITY_ATTRIBUTES), NULL, TRUE};
+#else
   tb_pipe_file_ref_t out_pipe[2]= {tb_null};
+#endif
+
   if (stdout_mode == redirect_mode::file) {
     attr.outtype = TB_PROCESS_REDIRECT_TYPE_FILEPATH;
     attr.out.path= stdout_path;
@@ -196,13 +208,22 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
     attr.outmode= TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | TB_FILE_MODE_TRUNC;
   }
   else if (need_stdout_pipe) {
+#ifdef _WIN32
+    CreatePipe (&h_out_read, &h_out_write, &sa, 0);
+    SetHandleInformation (h_out_read, HANDLE_FLAG_INHERIT, 0);
+    attr.outtype = TB_PROCESS_REDIRECT_TYPE_FILE;
+    attr.out.file= (tb_file_ref_t) h_out_write;
+#else
     tb_size_t mode[2]= {TB_PIPE_MODE_RO, TB_PIPE_MODE_WO};
     tb_pipe_file_init_pair (out_pipe, mode, 0);
     attr.outtype = TB_PROCESS_REDIRECT_TYPE_PIPE;
     attr.out.pipe= out_pipe[1];
+#endif
   }
 
+#ifndef _WIN32
   tb_pipe_file_ref_t err_pipe[2]= {tb_null};
+#endif
   if (stderr_mode == redirect_mode::file) {
     attr.errtype = TB_PROCESS_REDIRECT_TYPE_FILEPATH;
     attr.err.path= stderr_path;
@@ -217,6 +238,18 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
 #endif
     attr.errmode= TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | TB_FILE_MODE_TRUNC;
   }
+#ifdef _WIN32
+  else if (stderr_to_stdout && h_out_write) {
+    attr.errtype = TB_PROCESS_REDIRECT_TYPE_FILE;
+    attr.err.file= (tb_file_ref_t) h_out_write;
+  }
+  else if (stderr_mode == redirect_mode::tee || stderr_mode == redirect_mode::capture) {
+    CreatePipe (&h_err_read, &h_err_write, &sa, 0);
+    SetHandleInformation (h_err_read, HANDLE_FLAG_INHERIT, 0);
+    attr.errtype = TB_PROCESS_REDIRECT_TYPE_FILE;
+    attr.err.file= (tb_file_ref_t) h_err_write;
+  }
+#else
   else if (stderr_to_stdout && out_pipe[1]) {
     attr.errtype = TB_PROCESS_REDIRECT_TYPE_PIPE;
     attr.err.pipe= out_pipe[1];
@@ -227,13 +260,36 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
     attr.errtype = TB_PROCESS_REDIRECT_TYPE_PIPE;
     attr.err.pipe= err_pipe[1];
   }
+#endif
 
+#ifndef _WIN32
   tb_pipe_file_ref_t in_pipe[2]= {tb_null};
+#endif
   if (stdin_path) {
     attr.intype = TB_PROCESS_REDIRECT_TYPE_FILEPATH;
     attr.in.path= stdin_path;
     attr.inmode = TB_FILE_MODE_RO;
   }
+#ifdef _WIN32
+  else if (stdin_null) {
+    CreatePipe (&h_in_read, &h_in_write, &sa, 0);
+    SetHandleInformation (h_in_write, HANDLE_FLAG_INHERIT, 0);
+    attr.intype = TB_PROCESS_REDIRECT_TYPE_FILE;
+    attr.in.file= (tb_file_ref_t) h_in_read;
+    CloseHandle (h_in_write);
+    h_in_write= NULL;
+  }
+  else if (input) {
+    CreatePipe (&h_in_read, &h_in_write, &sa, 0);
+    SetHandleInformation (h_in_write, HANDLE_FLAG_INHERIT, 0);
+    attr.intype  = TB_PROCESS_REDIRECT_TYPE_FILE;
+    attr.in.file = (tb_file_ref_t) h_in_read;
+    DWORD written= 0;
+    WriteFile (h_in_write, input, (DWORD) input_len, &written, NULL);
+    CloseHandle (h_in_write);
+    h_in_write= NULL;
+  }
+#else
   else if (stdin_null) {
     tb_size_t mode[2]= {TB_PIPE_MODE_RO, TB_PIPE_MODE_WO};
     tb_pipe_file_init_pair (in_pipe, mode, 0);
@@ -249,6 +305,7 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
     tb_pipe_file_write (in_pipe[1], (tb_byte_t*) input, input_len);
     tb_pipe_file_exit (in_pipe[1]);
   }
+#endif
 
   tb_process_ref_t process= tb_null;
   if (s7_is_string (cmd_arg)) {
@@ -282,8 +339,23 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
     }
   }
 
+#ifdef _WIN32
+  if (h_out_write) {
+    CloseHandle (h_out_write);
+    h_out_write= NULL;
+  }
+  if (h_err_write) {
+    CloseHandle (h_err_write);
+    h_err_write= NULL;
+  }
+  if (h_in_read) {
+    CloseHandle (h_in_read);
+    h_in_read= NULL;
+  }
+#else
   if (out_pipe[1]) tb_pipe_file_exit (out_pipe[1]);
   if (err_pipe[1]) tb_pipe_file_exit (err_pipe[1]);
+#endif
 
   string    stdout_str;
   string    stderr_str;
@@ -298,6 +370,37 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
       status= -1;
     }
 
+#ifdef _WIN32
+    if (h_out_read) {
+      char  buf[4096];
+      DWORD n= 0;
+      while (ReadFile (h_out_read, buf, sizeof (buf) - 1, &n, NULL) && n > 0) {
+        buf[n]= '\0';
+        stdout_str.append (buf, n);
+        if (stdout_mode == redirect_mode::tee) {
+          fwrite (buf, 1, n, stdout);
+          fflush (stdout);
+        }
+      }
+      CloseHandle (h_out_read);
+      h_out_read= NULL;
+    }
+
+    if (h_err_read) {
+      char  buf[4096];
+      DWORD n= 0;
+      while (ReadFile (h_err_read, buf, sizeof (buf) - 1, &n, NULL) && n > 0) {
+        buf[n]= '\0';
+        stderr_str.append (buf, n);
+        if (stderr_mode == redirect_mode::tee) {
+          fwrite (buf, 1, n, stderr);
+          fflush (stderr);
+        }
+      }
+      CloseHandle (h_err_read);
+      h_err_read= NULL;
+    }
+#else
     if (out_pipe[0]) {
       char      buf[4096];
       tb_long_t n;
@@ -325,9 +428,14 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
       }
       tb_pipe_file_exit (err_pipe[0]);
     }
+#endif
 
     tb_process_exit (process);
   }
+#ifdef _WIN32
+  if (h_out_read) CloseHandle (h_out_read);
+  if (h_err_read) CloseHandle (h_err_read);
+#endif
 
   s7_pointer out_s7 = s7_make_string (sc, stdout_str.c_str ());
   s7_pointer err_s7 = s7_make_string (sc, stderr_str.c_str ());

--- a/tests/liii/subprocess/run-pipe-test.scm
+++ b/tests/liii/subprocess/run-pipe-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii either) (liii os) (liii subprocess))
+(import (liii check) (liii either) (liii os) (liii string) (liii subprocess))
 
 ;; run-pipe
 ;; 将多个命令串联为管道（替代 shell 的 |）。
@@ -43,12 +43,26 @@
 ) ;when
 
 (when (os-windows?)
-  ;; run-pipe relies on :stdout 'capture internally, which doesn't work reliably on Windows
-  ;; multi-command pipe fails because capture returns empty string
-  (check (either-left? (run-pipe "python3 -c print('hello')" "python3 -c pass")) => #t)
-
-  ;; single command pipe succeeds because the command exits with 0 (though output is empty)
+  (check (either-right? (run-pipe "python3 -c \"print('hello world')\""
+                          "python3 -c \"import sys; print(sys.stdin.read().strip())\""
+                        ) ;run-pipe
+         ) ;either-right?
+    =>
+    #t
+  ) ;check
+  (check (string-trim-both (to-right (run-pipe "python3 -c \"print('hello world')\""
+                                       "python3 -c \"import sys; print(sys.stdin.read().strip())\""
+                                     ) ;run-pipe
+                           ) ;to-right
+         ) ;string-trim-both
+    =>
+    "hello world"
+  ) ;check
   (check (either-right? (run-pipe "python3 -c pass")) => #t)
+  (check (either-left? (run-pipe "python3 -c \"print('hello')\"" "python3 -c 1/0"))
+    =>
+    #t
+  ) ;check
 ) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-values-test.scm
+++ b/tests/liii/subprocess/run-values-test.scm
@@ -1,4 +1,10 @@
-(import (liii check) (liii os) (liii path) (liii string) (liii subprocess) (scheme file))
+(import (liii check)
+  (liii os)
+  (liii path)
+  (liii string)
+  (liii subprocess)
+  (scheme file)
+) ;import
 
 ;; run-values
 ;; 执行命令并多值返回 stdout、stderr 和退出码。
@@ -119,6 +125,25 @@
 ) ;when
 
 (when (os-windows?)
+  (let-values (((out err code) (run-values "python3 -c \"print('hello')\"" :stdout 'capture)))
+    (check (string-trim-both out) => "hello")
+    (check (zero? code) => #t)
+  ) ;let-values
+
+  ;; :input
+  (let-values (((out err code)
+                (run-values "python3 -c \"import sys; print(sys.stdin.read().strip())\""
+                  :input
+                  "hello world"
+                  :stdout
+                  'capture
+                ) ;run-values
+               ) ;
+              ) ;
+    (check (string-trim-both out) => "hello world")
+    (check (zero? code) => #t)
+  ) ;let-values
+
   (let-values (((out err code) (run-values "python3 -c pass")))
     (check out => "")
     (check (zero? code) => #t)
@@ -131,26 +156,48 @@
 
   ;; :env (need to preserve PATH on Windows)
   (let ((path-env (getenv "PATH"))
-        (tmpfile (string-append (os-temp-dir) "/gf-run-values-env-win.txt")))
-    (when (file-exists? tmpfile) (delete-file tmpfile))
-    (let-values (((out err code) (run-values "python3 -c pass" :env `(("FOO" . "bar") ("PATH" . ,path-env)) :stdout tmpfile)))
-      (check (zero? code) => #t))
-    (when (file-exists? tmpfile) (delete-file tmpfile))
+        (tmpfile (string-append (os-temp-dir) "/gf-run-values-env-win.txt"))
+       ) ;
+    (when (file-exists? tmpfile)
+      (delete-file tmpfile)
+    ) ;when
+    (let-values (((out err code)
+                  (run-values "python3 -c pass"
+                    :env
+                    `((,"FOO" . ,"bar") (,"PATH" . ,path-env))
+                    :stdout
+                    tmpfile
+                  ) ;run-values
+                 ) ;
+                ) ;
+      (check (zero? code) => #t)
+    ) ;let-values
+    (when (file-exists? tmpfile)
+      (delete-file tmpfile)
+    ) ;when
   ) ;let
 
   ;; :timeout
-  (let-values (((out err code) (run-values "python3 -c \"import time; time.sleep(10)\"" :timeout 1)))
+  (let-values (((out err code)
+                (run-values "python3 -c \"import time; time.sleep(10)\"" :timeout 1)
+               ) ;
+              ) ;
     (check code => -1)
   ) ;let-values
 
   ;; :stdout to file
   (let ((tmpfile (string-append (os-temp-dir) "/gf-run-values-stdout-win.txt")))
-    (when (file-exists? tmpfile) (delete-file tmpfile))
+    (when (file-exists? tmpfile)
+      (delete-file tmpfile)
+    ) ;when
     (let-values (((out err code) (run-values "python3 -c print('hello')" :stdout tmpfile)))
       (check out => "")
       (check (zero? code) => #t)
-      (check (path-read-text tmpfile) => "hello\n"))
-    (when (file-exists? tmpfile) (delete-file tmpfile))
+      (check (path-read-text tmpfile) => "hello\n")
+    ) ;let-values
+    (when (file-exists? tmpfile)
+      (delete-file tmpfile)
+    ) ;when
   ) ;let
 
   ;; :stdout 'discard
@@ -167,15 +214,29 @@
 
   ;; :stdin from file
   (let ((infile (string-append (os-temp-dir) "/gf-run-values-stdin-win.txt"))
-        (outfile (string-append (os-temp-dir) "/gf-run-values-stdin-out-win.txt")))
-    (when (file-exists? outfile) (delete-file outfile))
+        (outfile (string-append (os-temp-dir) "/gf-run-values-stdin-out-win.txt"))
+       ) ;
+    (when (file-exists? outfile)
+      (delete-file outfile)
+    ) ;when
     (call-with-output-file infile (lambda (p) (display "file content\n" p)))
-    (let ((cmd (string-append "python3 -c \"import sys; open('" (string-replace outfile "\\" "/") "','w').write(sys.stdin.read())\"")))
+    (let ((cmd (string-append "python3 -c \"import sys; open('"
+                 (string-replace outfile "\\" "/")
+                 "','w').write(sys.stdin.read())\""
+               ) ;string-append
+          ) ;cmd
+         ) ;
       (let-values (((out err code) (run-values cmd :stdin infile)))
-        (check (zero? code) => #t))
-      (check (path-read-text outfile) => "file content\n"))
-    (when (file-exists? infile) (delete-file infile))
-    (when (file-exists? outfile) (delete-file outfile))
+        (check (zero? code) => #t)
+      ) ;let-values
+      (check (path-read-text outfile) => "file content\n")
+    ) ;let
+    (when (file-exists? infile)
+      (delete-file infile)
+    ) ;when
+    (when (file-exists? outfile)
+      (delete-file outfile)
+    ) ;when
   ) ;let
 
   ;; :stdin 'null


### PR DESCRIPTION
# [0139] 修复 Windows 平台 subprocess 管道捕获导致 gf pr / run-values 失败的问题

## 任务相关的代码文件
- src/liii_subprocess.cpp
- tests/liii/subprocess/run-values-test.scm
- tests/liii/subprocess/run-pipe-test.scm

## 如何测试
```bash
xmake b goldfish
bin/gf tests/liii/subprocess/run-values-test.scm
bin/gf tests/liii/subprocess/run-pipe-test.scm
bin/gf test tools/pr/tests/liii/goldpr/parse-pr-args-test.scm
bin/gf test tools/pr/tests/liii/goldpr/pr-remote-url-test.scm
```

## 2026-08-31 修复 Windows 下 subprocess 管道捕获

### What
1. 修复 Windows 平台上 `(liii subprocess)` 在执行管道重定向（`:stdout 'capture`、`:stderr 'capture`、`:input`、`run-pipe`）时无法正确捕获输出甚至报错的问题。
2. 修复 `gf pr` 在 Windows 下因 `pr-remote-url` 无法捕获 git 输出而误报 `Error: no origin remote found in this repository` 的问题。
3. 补全并在 Windows 下启用 `run-values-test.scm` 和 `run-pipe-test.scm` 的捕获与管道断言测试。

### Why
在 Windows 平台上，tbox 的 `tb_pipe_file_init_pair` 内部通过带有 `FILE_FLAG_OVERLAPPED` 标志的具名管道实现异步 I/O。当子进程（如 Git、Python 或标准 C 运行时程序）继承该句柄并使用同步 `WriteFile` 写入时，Windows API 会返回 `ERROR_INVALID_PARAMETER` (Errno 22)，导致写入失败、输出捕获为空字符串。

### How
1. 在 Windows 平台（`_WIN32`）下，使用原生 Win32 API `CreatePipe` 创建同步管道，句柄传递给子进程的 `attr.out.file` / `attr.err.file` / `attr.in.file` 并标记继承。
2. 父进程在启动子进程后关闭管道的写端/读端无用句柄，避免阻塞 EOF。
3. 父进程使用同步 `ReadFile` 循环读取子进程管道输出直至 EOF，正确填充 `stdout_str` / `stderr_str`。
4. 更新 `tests/liii/subprocess/run-values-test.scm` 与 `run-pipe-test.scm`，加入 Windows 平台的管道捕获与串联管道验证。
