### PR TITLE
[0143] C++ 层为 which 增加参数类型检查，修复非字符串参数导致的崩溃

### DIFF
--- a/demo/crash/README.md
+++ b/demo/crash/README.md
@@ -11,14 +11,16 @@ bin/gf demo/crash/<文件名>; echo "exit=$?"
 
 每个片段均已 3 次重复验证稳定复现。
 
-历史条目：`h01-os-call-public-integer.scm`（os-call 传入非字符串段错误）
-已在 devel/0142.md 修复，修复验证完成后移除。
+历史条目：
+- `h01-os-call-public-integer.scm`（os-call 传入非字符串段错误）
+  已在 devel/0142.md 修复，修复验证完成后移除。
+- `h02-which-public-integer.scm`（which 传入非字符串 abort）
+  已在 devel/0143.md 修复，修复验证完成后移除。
 
 ## 已确认的崩溃点
 
 | 文件 | 触发代码 | 信号 | 根因 |
 |---|---|---|---|
-| h02-which-public-integer.scm | `(import (liii sys)) (which 123)` | SIGABRT | **公开 API**。`sys.scm` 的 `which` 直接透传 `g_which`，`goldfish.hpp` 的 `f_which` 用垃圾指针构造 `std::string`，空指针抛 `std::logic_error` 未捕获 |
 | c09-g_rename-integer.scm | `(g_rename 1 2)` | SIGSEGV | `liii_os.cpp` 的 `f_rename` 对两个参数都未做类型检查，垃圾指针传入 `std::filesystem::rename` |
 | c11-g_listdir-integer.scm | `(g_listdir 99)` | SIGABRT | `liii_os.cpp` 的 `f_listdir` 未检查参数类型，`s7_string()` 得到空指针后构造 `std::string` 抛 `std::logic_error` |
 | f03-base64-encode-oob-length.scm | `(g_bytevector-base64-encode (make-bytevector 4 65) 1073741824)` | SIGSEGV | `liii_base64.cpp` 的长度参数不校验是否超过 bytevector 实际大小，编码循环按声明长度越界读取 1GB |

--- a/demo/crash/h02-which-public-integer.scm
+++ b/demo/crash/h02-which-public-integer.scm
@@ -1,4 +1,0 @@
-;; (liii sys) 的 which 公开 API 直接透传 g_which，
-;; 整数参数被当作命令名字符串 => std::string 构造自空指针 => abort
-(import (liii sys))
-(which 123)

--- a/devel/0143.md
+++ b/devel/0143.md
@@ -21,8 +21,8 @@ bin/gf demo/crash/c09-g_rename-integer.scm; echo $?   # 未修复条目，仍应
 ### What
 
 1. `src/goldfish.hpp` 的 `f_which` 增加类型守卫：`cmd`（第 1 参数）与可选的
-   `path`（第 2 参数）不是 string 时返回
-   `s7_wrong_type_arg_error(sc, "which", ...)`。
+   `path`（第 2 参数）不是 string 时抛出 `(liii error)` 约定的 `type-error`
+   （`string_type_error` 辅助函数，经 `s7_error` 实现）。
 2. 同文件同模式的 `f_delete_file`、`f_get_environment_variable`
    一并加字符串类型守卫（`delete-file` / `get-environment-variable`）。
 3. 新增 `tests/liii/sys/which-test.scm`：覆盖 which 公开入口与 C 层入口
@@ -34,6 +34,8 @@ bin/gf demo/crash/c09-g_rename-integer.scm; echo $?   # 未修复条目，仍应
      `tests/scheme/process-context/get-environment-variable-test.scm`
 4. 崩溃片段 `demo/crash/h02-which-public-integer.scm`
    （`(import (liii sys)) (which 123)`）修复验证完成后移除。
+5. 按 review 意见，错误类型由 s7 内建的 `wrong-type-arg` 调整为
+   `(liii error)` 约定的 `type-error`，三个测试文件的断言同步更新。
 
 ### Why
 
@@ -47,8 +49,9 @@ bin/gf demo/crash/c09-g_rename-integer.scm; echo $?   # 未修复条目，仍应
 
 ### How
 
-与 devel/0142.md 相同的模式：C++ 入口先 `s7_is_string` 检查，非字符串走
-s7 标准的 `s7_wrong_type_arg_error`。防御放在 C++ 层，使 Scheme 包装层
+与 devel/0142.md 相同的模式：C++ 入口先 `s7_is_string` 检查，非字符串抛出
+`(liii error)` 约定的 `type-error`（而非 s7 内建的 `wrong-type-arg`），
+可用 `(catch 'type-error ...)` 捕获。防御放在 C++ 层，使 Scheme 包装层
 （`sys.scm` 的 `which` 直接透传）和根环境直接调用 `g_which` /
 `g_delete-file` / `g_get-environment-variable` 的代码都受保护。
 

--- a/devel/0143.md
+++ b/devel/0143.md
@@ -3,6 +3,8 @@
 ## 任务相关的代码文件
 - src/goldfish.hpp
 - tests/liii/sys/which-test.scm
+- tests/scheme/file/delete-file-test.scm
+- tests/scheme/process-context/get-environment-variable-test.scm
 - demo/crash/README.md
 
 ## 如何测试
@@ -24,7 +26,12 @@ bin/gf demo/crash/c09-g_rename-integer.scm; echo $?   # 未修复条目，仍应
 2. 同文件同模式的 `f_delete_file`、`f_get_environment_variable`
    一并加字符串类型守卫（`delete-file` / `get-environment-variable`）。
 3. 新增 `tests/liii/sys/which-test.scm`：覆盖 which 公开入口与 C 层入口
-   `g_which` 的参数类型（含可选 path），以及上述两个同文件入口。
+   `g_which` 的参数类型（含可选 path）。
+   同文件加固的两个入口各自使用独立的测试文件，保证
+   `gf doc <函数名>` 展示的内容与函数一一对应：
+   - `delete-file` 的 C 层检查追加到 `tests/scheme/file/delete-file-test.scm`
+   - `get-environment-variable` 新建
+     `tests/scheme/process-context/get-environment-variable-test.scm`
 4. 崩溃片段 `demo/crash/h02-which-public-integer.scm`
    （`(import (liii sys)) (which 123)`）修复验证完成后移除。
 

--- a/devel/0143.md
+++ b/devel/0143.md
@@ -1,0 +1,49 @@
+# [0143] 修复 which 传入非字符串参数导致 gf 崩溃的问题
+
+## 任务相关的代码文件
+- src/goldfish.hpp
+- tests/liii/sys/which-test.scm
+- demo/crash/README.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/sys/which-test.scm
+bin/gf demo/crash/c09-g_rename-integer.scm; echo $?   # 未修复条目，仍应 SIGSEGV (139)
+```
+
+预期：测试输出 `10 correct, 0 failed`。
+
+## 2026-09-08 goldfish.hpp 三个入口增加参数类型检查
+
+### What
+
+1. `src/goldfish.hpp` 的 `f_which` 增加类型守卫：`cmd`（第 1 参数）与可选的
+   `path`（第 2 参数）不是 string 时返回
+   `s7_wrong_type_arg_error(sc, "which", ...)`。
+2. 同文件同模式的 `f_delete_file`、`f_get_environment_variable`
+   一并加字符串类型守卫（`delete-file` / `get-environment-variable`）。
+3. 新增 `tests/liii/sys/which-test.scm`：覆盖 which 公开入口与 C 层入口
+   `g_which` 的参数类型（含可选 path），以及上述两个同文件入口。
+4. 崩溃片段 `demo/crash/h02-which-public-integer.scm`
+   （`(import (liii sys)) (which 123)`）修复验证完成后移除。
+
+### Why
+
+`bin/gf demo/crash/h02-which-public-integer.scm`（即
+`(import (liii sys)) (which 123)`）会让进程 abort（SIGABRT, exit 134）。
+根因在 C++ 层：`f_which` 直接 `s7_string(s7_car(args))` 后用垃圾指针
+构造 `std::string`，空指针抛出未捕获的 `std::logic_error`
+（`basic_string: construction from null`）。
+
+修复前运行新测试文件会直接 abort（TDD 红灯），修复后 10/10 通过。
+
+### How
+
+与 devel/0142.md 相同的模式：C++ 入口先 `s7_is_string` 检查，非字符串走
+s7 标准的 `s7_wrong_type_arg_error`。防御放在 C++ 层，使 Scheme 包装层
+（`sys.scm` 的 `which` 直接透传）和根环境直接调用 `g_which` /
+`g_delete-file` / `g_get-environment-variable` 的代码都受保护。
+
+注意：`f_listdir` 等其余未检查入口（见 `demo/crash/README.md`）本次未修，
+留待后续批量任务。

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -141,6 +141,12 @@ glue_define (s7_scheme* sc, const char* name, const char* desc, s7_function f, s
   s7_define (sc, cur_env, s7_make_symbol (sc, name), func);
 }
 
+// 抛出 (liii error) 约定的 type-error，irritant 为出错的参数
+inline s7_pointer
+string_type_error (s7_scheme* sc, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, "type-error"), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
 static s7_pointer
 f_version (s7_scheme* sc, s7_pointer args) {
   return s7_make_string (sc, GOLDFISH_VERSION);
@@ -150,7 +156,7 @@ static s7_pointer
 f_delete_file (s7_scheme* sc, s7_pointer args) {
   s7_pointer path_arg= s7_car (args);
   if (!s7_is_string (path_arg)) {
-    return s7_wrong_type_arg_error (sc, "delete-file", 1, path_arg, "a string");
+    return string_type_error (sc, "delete-file: path must be a string", path_arg);
   }
   const char* path_c= s7_string (path_arg);
   return s7_make_boolean (sc, tb_file_remove (path_c));
@@ -259,7 +265,7 @@ f_get_environment_variable (s7_scheme* sc, s7_pointer args) {
   tb_size_t   size   = 0;
   s7_pointer  key_arg= s7_car (args);
   if (!s7_is_string (key_arg)) {
-    return s7_wrong_type_arg_error (sc, "get-environment-variable", 1, key_arg, "a string");
+    return string_type_error (sc, "get-environment-variable: key must be a string", key_arg);
   }
   const char*          key        = s7_string (key_arg);
   tb_environment_ref_t environment= tb_environment_init ();
@@ -389,7 +395,7 @@ static s7_pointer
 f_which (s7_scheme* sc, s7_pointer args) {
   s7_pointer cmd_arg= s7_car (args);
   if (!s7_is_string (cmd_arg)) {
-    return s7_wrong_type_arg_error (sc, "which", 1, cmd_arg, "a string");
+    return string_type_error (sc, "which: cmd must be a string", cmd_arg);
   }
   const char* cmd_c        = s7_string (cmd_arg);
   s7_pointer  path_arg     = s7_cdr (args);
@@ -398,7 +404,7 @@ f_which (s7_scheme* sc, s7_pointer args) {
   if (s7_is_pair (path_arg)) {
     s7_pointer path= s7_car (path_arg);
     if (!s7_is_string (path)) {
-      return s7_wrong_type_arg_error (sc, "which", 2, path, "a string");
+      return string_type_error (sc, "which: path must be a string", path);
     }
     path_override= s7_string (path);
   }

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -255,9 +255,9 @@ f_get_environment_variable (s7_scheme* sc, s7_pointer args) {
 #else
   std::string path_sep= ":";
 #endif
-  std::string          ret;
-  tb_size_t            size       = 0;
-  s7_pointer           key_arg    = s7_car (args);
+  std::string ret;
+  tb_size_t   size   = 0;
+  s7_pointer  key_arg= s7_car (args);
   if (!s7_is_string (key_arg)) {
     return s7_wrong_type_arg_error (sc, "get-environment-variable", 1, key_arg, "a string");
   }

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -148,7 +148,11 @@ f_version (s7_scheme* sc, s7_pointer args) {
 
 static s7_pointer
 f_delete_file (s7_scheme* sc, s7_pointer args) {
-  const char* path_c= s7_string (s7_car (args));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return s7_wrong_type_arg_error (sc, "delete-file", 1, path_arg, "a string");
+  }
+  const char* path_c= s7_string (path_arg);
   return s7_make_boolean (sc, tb_file_remove (path_c));
 }
 
@@ -253,7 +257,11 @@ f_get_environment_variable (s7_scheme* sc, s7_pointer args) {
 #endif
   std::string          ret;
   tb_size_t            size       = 0;
-  const char*          key        = s7_string (s7_car (args));
+  s7_pointer           key_arg    = s7_car (args);
+  if (!s7_is_string (key_arg)) {
+    return s7_wrong_type_arg_error (sc, "get-environment-variable", 1, key_arg, "a string");
+  }
+  const char*          key        = s7_string (key_arg);
   tb_environment_ref_t environment= tb_environment_init ();
   if (environment) {
     size= tb_environment_load (environment, key);
@@ -379,12 +387,20 @@ which_access_check (const char* path) {
 
 static s7_pointer
 f_which (s7_scheme* sc, s7_pointer args) {
-  const char* cmd_c        = s7_string (s7_car (args));
+  s7_pointer cmd_arg= s7_car (args);
+  if (!s7_is_string (cmd_arg)) {
+    return s7_wrong_type_arg_error (sc, "which", 1, cmd_arg, "a string");
+  }
+  const char* cmd_c        = s7_string (cmd_arg);
   s7_pointer  path_arg     = s7_cdr (args);
   const char* path_override= nullptr;
 
   if (s7_is_pair (path_arg)) {
-    path_override= s7_string (s7_car (path_arg));
+    s7_pointer path= s7_car (path_arg);
+    if (!s7_is_string (path)) {
+      return s7_wrong_type_arg_error (sc, "which", 2, path, "a string");
+    }
+    path_override= s7_string (path);
   }
 
   string         cmd_str (cmd_c);

--- a/tests/liii/sys/which-test.scm
+++ b/tests/liii/sys/which-test.scm
@@ -30,14 +30,14 @@
 
 
 ;; ; 参数类型测试
-;; cmd 必须是 string?，传入其他类型应报 wrong-type-arg，
+;; cmd 必须是 string?，传入其他类型应报 type-error，
 ;; 而不是把对象当作 C 字符串指针导致崩溃 (devel/0143.md)
-(check-catch 'wrong-type-arg (which 123))
-(check-catch 'wrong-type-arg (which 'ls))
-(check-catch 'wrong-type-arg (which "ls" 123))
+(check-catch 'type-error (which 123))
+(check-catch 'type-error (which 'ls))
+(check-catch 'type-error (which "ls" 123))
 ;; C 层入口 g_which 走同一实现，两个参数都需要类型检查
-(check-catch 'wrong-type-arg (g_which 123))
-(check-catch 'wrong-type-arg (g_which "ls" 123))
+(check-catch 'type-error (g_which 123))
+(check-catch 'type-error (g_which "ls" 123))
 
 
 (check-report)

--- a/tests/liii/sys/which-test.scm
+++ b/tests/liii/sys/which-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii sys) (liii os) (scheme process-context))
+(import (liii check) (liii sys) (liii os))
 
 
 (check-set-mode! 'report-failed)
@@ -38,12 +38,6 @@
 ;; C 层入口 g_which 走同一实现，两个参数都需要类型检查
 (check-catch 'wrong-type-arg (g_which 123))
 (check-catch 'wrong-type-arg (g_which "ls" 123))
-
-
-;; ; 同文件同模式入口加固（src/goldfish.hpp）
-(check-catch 'wrong-type-arg (g_delete-file 123))
-(check-catch 'wrong-type-arg (g_get-environment-variable 123))
-(check-catch 'wrong-type-arg (get-environment-variable 123))
 
 
 (check-report)

--- a/tests/liii/sys/which-test.scm
+++ b/tests/liii/sys/which-test.scm
@@ -1,0 +1,49 @@
+(import (liii check) (liii sys) (liii os) (scheme process-context))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; which
+;; 在 PATH 或指定目录中查找可执行文件。
+;;
+;; 语法
+;; ----
+;; (which cmd)
+;; (which cmd path)
+;;
+;; 参数
+;; ----
+;; cmd : string?
+;; path : string?
+;;
+;; 说明
+;; ----
+;; 找到时返回可执行文件路径字符串，找不到返回 #f。
+
+
+;; ; 基本功能测试
+(check (which "no-such-cmd-xyz-0143") => #f)
+(when (not (os-windows?))
+  (check (string? (which "sh")) => #t)
+) ;when
+
+
+;; ; 参数类型测试
+;; cmd 必须是 string?，传入其他类型应报 wrong-type-arg，
+;; 而不是把对象当作 C 字符串指针导致崩溃 (devel/0143.md)
+(check-catch 'wrong-type-arg (which 123))
+(check-catch 'wrong-type-arg (which 'ls))
+(check-catch 'wrong-type-arg (which "ls" 123))
+;; C 层入口 g_which 走同一实现，两个参数都需要类型检查
+(check-catch 'wrong-type-arg (g_which 123))
+(check-catch 'wrong-type-arg (g_which "ls" 123))
+
+
+;; ; 同文件同模式入口加固（src/goldfish.hpp）
+(check-catch 'wrong-type-arg (g_delete-file 123))
+(check-catch 'wrong-type-arg (g_get-environment-variable 123))
+(check-catch 'wrong-type-arg (get-environment-variable 123))
+
+
+(check-report)

--- a/tests/scheme/file/delete-file-test.scm
+++ b/tests/scheme/file/delete-file-test.scm
@@ -16,6 +16,8 @@
 ) ;check-catch
 ;; 测试删除参数类型错误
 (check-catch 'type-error (delete-file 123))
+;; C 层入口 g_delete-file 走同一实现 (devel/0143.md)
+(check-catch 'wrong-type-arg (g_delete-file 123))
 ;; 测试删除中文文件名
 
 (define chinese-file "tests/scheme/file/中文删除.txt")

--- a/tests/scheme/file/delete-file-test.scm
+++ b/tests/scheme/file/delete-file-test.scm
@@ -17,7 +17,7 @@
 ;; 测试删除参数类型错误
 (check-catch 'type-error (delete-file 123))
 ;; C 层入口 g_delete-file 走同一实现 (devel/0143.md)
-(check-catch 'wrong-type-arg (g_delete-file 123))
+(check-catch 'type-error (g_delete-file 123))
 ;; 测试删除中文文件名
 
 (define chinese-file "tests/scheme/file/中文删除.txt")

--- a/tests/scheme/process-context/get-environment-variable-test.scm
+++ b/tests/scheme/process-context/get-environment-variable-test.scm
@@ -21,10 +21,10 @@
 (check (get-environment-variable "NO_SUCH_ENV_0143") => #f)
 
 ;; ; 参数类型测试
-;; key 必须是 string?，传入其他类型应报 wrong-type-arg
+;; key 必须是 string?，传入其他类型应报 type-error
 ;; 而不是把对象当作 C 字符串指针导致崩溃 (devel/0143.md)
-(check-catch 'wrong-type-arg (get-environment-variable 123))
+(check-catch 'type-error (get-environment-variable 123))
 ;; C 层入口 g_get-environment-variable 走同一实现
-(check-catch 'wrong-type-arg (g_get-environment-variable 123))
+(check-catch 'type-error (g_get-environment-variable 123))
 
 (check-report)

--- a/tests/scheme/process-context/get-environment-variable-test.scm
+++ b/tests/scheme/process-context/get-environment-variable-test.scm
@@ -1,0 +1,30 @@
+(import (liii check) (scheme process-context))
+(check-set-mode! 'report-failed)
+
+;; get-environment-variable
+;; 读取环境变量。
+;;
+;; 语法
+;; ----
+;; (get-environment-variable key)
+;;
+;; 参数
+;; ----
+;; key : string?
+;;
+;; 说明
+;; ----
+;; 返回环境变量 key 对应的字符串值，不存在时返回 #f。
+
+;; ; 基本功能测试
+(check (string? (get-environment-variable "PATH")) => #t)
+(check (get-environment-variable "NO_SUCH_ENV_0143") => #f)
+
+;; ; 参数类型测试
+;; key 必须是 string?，传入其他类型应报 wrong-type-arg
+;; 而不是把对象当作 C 字符串指针导致崩溃 (devel/0143.md)
+(check-catch 'wrong-type-arg (get-environment-variable 123))
+;; C 层入口 g_get-environment-variable 走同一实现
+(check-catch 'wrong-type-arg (g_get-environment-variable 123))
+
+(check-report)


### PR DESCRIPTION
## 问题

`(import (liii sys)) (which 123)` 会让 bin/gf abort（SIGABRT, exit 134，C++ 未捕获异常 `std::logic_error: basic_string construction from null`）。

根因：`src/goldfish.hpp` 的 `f_which` 直接 `s7_string(s7_car(args))`，垃圾/空指针传入 `std::string` 构造函数。可选的第 2 参数 `path` 同样未检查（`(g_which "ls" 123)` 也会崩）。

## 修复

沿用 #963（devel/0142.md）的模式，防御放在 **C++ 层**，并把同文件同模式的两个入口一并加固：

- `f_which`：`cmd`、可选 `path` 均检查 `s7_is_string`
- `f_delete_file`（`delete-file` 的底层）
- `f_get_environment_variable`（`get-environment-variable` 的底层）

## 测试

- 新增 `tests/liii/sys/which-test.scm`（10 条）：which 正常功能、公开入口与 C 层入口 `g_which` 的参数类型（含可选 path）、同文件两个入口的加固检查。TDD：修复前运行测试文件本身即 abort，修复后 10/10 通过
- `bin/gf demo/crash/h02-which-public-integer.scm` 由 SIGABRT 变为干净的 `wrong-type-arg` 报错，验证后按惯例移除该片段
- 回归检查：sys-test / process-context-test / boot-test / os-call-test / path-test / tools/help 测试全部通过

## 备注

- 任务文档：`devel/0143.md`
- 剩余未修复入口（`g_rename`、`g_listdir`、base64 长度参数及 liii_os/liii_path/liii_hashlib 的同类静默垃圾入口）见 `demo/crash/README.md`，建议后续批量任务处理