### PR TITLE
[0142] os-call 参数类型错误改抛 type-error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,13 @@ bin/gf tests/goldfish/liii/xxx-test.scm
 ;; Licensed under the Apache License, Version 2.0 ...
 ```
 
+### 类型错误命名规范
+对于新增的代码，优先使用 `type-error` 而不是 `wrong-type-arg`：
+- `type-error` 命名更规范且容易记忆，符合 Goldfish Scheme 错误体系规范
+- 在 Scheme 包装层使用 `(type-error ...)`
+- 在 C/C++ 胶水层使用 `s7_error(sc, s7_make_symbol(sc, "type-error"), ...)`
+- 测试用例使用 `(check-catch 'type-error ...)`
+
 ### define-case-class 使用建议
 `define-case-class` 通过宏实现，有显著的性能开销：
 - 方法调用需要通过字符串匹配和动态查找

--- a/devel/0142.md
+++ b/devel/0142.md
@@ -1,6 +1,7 @@
 # [0142] 修复 os-call 传入非字符串参数导致 gf 段错误的问题
 
 ## 任务相关的代码文件
+- CLAUDE.md
 - src/liii_os.cpp
 - tests/liii/os/os-call-test.scm
 - demo/crash/ (崩溃片段及其索引 README)
@@ -8,10 +9,23 @@
 ## 如何测试
 ```bash
 xmake b goldfish
+bin/gf fmt tests/liii/os/os-call-test.scm
 bin/gf tests/liii/os/os-call-test.scm
 ```
 
 预期：测试输出 `6 correct, 0 failed`。
+
+## 2026-09-08 os-call 统一抛出 type-error
+
+### What
+
+1. `src/liii_os.cpp` 的 `f_os_call` 改用 `string_type_error` 辅助函数抛出 `type-error` 代替 `wrong-type-arg`；Scheme 包装层 `os-call` 保持直接透传，由 C++ 层单一来源保证类型安全。
+2. `tests/liii/os/os-call-test.scm` 的文档及测试断言统一改为 `type-error`。
+3. 在 `CLAUDE.md` 明确规范：新增代码优先使用 `type-error` 而不是 `wrong-type-arg`。
+
+### Why
+
+`type-error` 符合 Goldfish Scheme 标准错误体系，比 s7 内置的 `wrong-type-arg` 更加规范、直观且容易记忆。由 C++ 底层统一做守卫可以同时保护 Scheme 包装层及直接调用 `g_os-call` 的场景，避免 Scheme 层出现冗余校验。
 
 ## 2026-09-08 C++ 层为 os-call 增加参数类型检查
 

--- a/src/liii_os.cpp
+++ b/src/liii_os.cpp
@@ -112,7 +112,7 @@ static s7_pointer
 f_os_call (s7_scheme* sc, s7_pointer args) {
   s7_pointer cmd_arg= s7_car (args);
   if (!s7_is_string (cmd_arg)) {
-    return s7_wrong_type_arg_error (sc, "os-call", 1, cmd_arg, "a string");
+    return string_type_error (sc, "os-call: command must be a string", cmd_arg);
   }
   const char*       cmd_c= s7_string (cmd_arg);
   tb_process_attr_t attr = {tb_null};

--- a/tests/liii/os/os-call-test.scm
+++ b/tests/liii/os/os-call-test.scm
@@ -19,6 +19,11 @@
 ;; 说明
 ;; ----
 ;; 执行指定的系统命令并等待其完成。
+;;
+;; 错误
+;; ----
+;; type-error
+;; 当 command 不是字符串时抛出错误。
 
 
 ;; ; 基本功能测试
@@ -33,14 +38,14 @@
 
 
 ;; ; 参数类型测试
-;; command 必须是 string?，传入其他类型应报 wrong-type-arg
+;; command 必须是 string?，传入其他类型应报 type-error
 ;; 而不是把整数等对象当作 C 字符串指针导致段错误 (devel/0142.md)
-(check-catch 'wrong-type-arg (os-call 42))
-(check-catch 'wrong-type-arg (os-call 'ls))
-(check-catch 'wrong-type-arg (os-call #t))
-(check-catch 'wrong-type-arg (os-call (list "ls")))
+(check-catch 'type-error (os-call 42))
+(check-catch 'type-error (os-call 'ls))
+(check-catch 'type-error (os-call #t))
+(check-catch 'type-error (os-call (list "ls")))
 ;; C 层入口 g_os-call 走同一实现，同样需要类型检查
-(check-catch 'wrong-type-arg (g_os-call 42))
+(check-catch 'type-error (g_os-call 42))
 
 
 (check-report)


### PR DESCRIPTION
详见 devel/0142.md

### 变更内容
1. C++ 胶水层 `f_os_call`：非字符串参数使用 `string_type_error` 辅助函数抛出 `type-error`（Scheme 包装层保持直接透传，由 C++ 层单一来源保证类型安全）
2. 单元测试 `tests/liii/os/os-call-test.scm`：文档和测试断言更新为 `type-error`
3. `CLAUDE.md`：增加“类型错误命名规范”，新增代码优先使用 `type-error` 而不是 `wrong-type-arg`