### PR TITLE
[0147] os-call 参数类型错误对齐 (liii error) 约定的 type-error

### DIFF
--- a/devel/0147.md
+++ b/devel/0147.md
@@ -1,0 +1,36 @@
+# [0147] os-call 的参数类型错误对齐 (liii error) 约定的 type-error
+
+## 任务相关的代码文件
+- src/liii_os.cpp
+- tests/liii/os/os-call-test.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/os/os-call-test.scm
+```
+
+预期：测试输出 `6 correct, 0 failed`。
+
+## 2026-09-08 os-call 错误类型对齐 type-error
+
+### What
+
+1. `src/liii_os.cpp` 的 `f_os_call` 类型守卫改为抛出
+   `(liii error)` 约定的 `type-error`（新增 `string_type_error` 辅助函数，
+   经 `s7_error` 实现），不再使用 s7 内建的 `wrong-type-arg`。
+2. `tests/liii/os/os-call-test.scm` 的 5 条错误断言由
+   `check-catch 'wrong-type-arg` 改为 `check-catch 'type-error`。
+
+### Why
+
+0143-0146（#964-#967）已统一约定：C 层守卫的参数类型错误抛出
+`(liii error)` 的 `type-error`。os-call 的守卫来自 #963（devel/0142.md），
+当时使用的是 `wrong-type-arg`，本任务将其对齐，保证整个 C 胶水层
+错误类型约定一致。
+
+### How
+
+与 devel/0143.md 相同的 `string_type_error` 辅助函数模式：
+`s7_error(sc, 'type-error, (list msg irritant))`，
+可用 `(catch 'type-error ...)` 捕获。

--- a/src/liii_os.cpp
+++ b/src/liii_os.cpp
@@ -69,6 +69,12 @@ string_vector_to_s7_vector (s7_scheme* sc, vector<string> v) {
   return ret;
 }
 
+// 抛出 (liii error) 约定的 type-error，irritant 为出错的参数
+inline s7_pointer
+string_type_error (s7_scheme* sc, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, "type-error"), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
 static s7_pointer
 f_os_arch (s7_scheme* sc, s7_pointer args) {
   return s7_make_string (sc, TB_ARCH_STRING);
@@ -106,7 +112,7 @@ static s7_pointer
 f_os_call (s7_scheme* sc, s7_pointer args) {
   s7_pointer cmd_arg= s7_car (args);
   if (!s7_is_string (cmd_arg)) {
-    return s7_wrong_type_arg_error (sc, "os-call", 1, cmd_arg, "a string");
+    return string_type_error (sc, "os-call: command must be a string", cmd_arg);
   }
   const char*       cmd_c= s7_string (cmd_arg);
   tb_process_attr_t attr = {tb_null};

--- a/tests/liii/os/os-call-test.scm
+++ b/tests/liii/os/os-call-test.scm
@@ -33,14 +33,14 @@
 
 
 ;; ; 参数类型测试
-;; command 必须是 string?，传入其他类型应报 wrong-type-arg
+;; command 必须是 string?，传入其他类型应报 type-error（(liii error) 约定）
 ;; 而不是把整数等对象当作 C 字符串指针导致段错误 (devel/0142.md)
-(check-catch 'wrong-type-arg (os-call 42))
-(check-catch 'wrong-type-arg (os-call 'ls))
-(check-catch 'wrong-type-arg (os-call #t))
-(check-catch 'wrong-type-arg (os-call (list "ls")))
+(check-catch 'type-error (os-call 42))
+(check-catch 'type-error (os-call 'ls))
+(check-catch 'type-error (os-call #t))
+(check-catch 'type-error (os-call (list "ls")))
 ;; C 层入口 g_os-call 走同一实现，同样需要类型检查
-(check-catch 'wrong-type-arg (g_os-call 42))
+(check-catch 'type-error (g_os-call 42))
 
 
 (check-report)


### PR DESCRIPTION
## 背景

#963（devel/0142.md）为 `os-call` 增加类型守卫时使用的是 s7 内建的 `wrong-type-arg`。#964-#967（0143-0146）按 review 意见统一了约定：C 层守卫的参数类型错误一律抛出 `(liii error)` 的 `type-error`。本 PR 把 os-call 对齐，保证整个 C 胶水层错误类型约定一致。

## 修复

- `f_os_call` 的类型守卫改用 `string_type_error` 辅助函数（`s7_error(sc, 'type-error, (list msg irritant))`），报错信息为 `os-call: command must be a string`
- `tests/liii/os/os-call-test.scm` 的 5 条错误断言改为 `check-catch 'type-error`

## 测试

- `bin/gf tests/liii/os/os-call-test.scm`：6/6 通过
- 与 #964-#967 的辅助函数实现完全一致

## 备注

- 任务文档：`devel/0147.md`
- 建议在 #964-#967 之后合并；均不冲突