### PR TITLE
[0147] C++ 层为 hashlib 全函数增加参数类型检查，修复非字符串参数导致的段错误

### DIFF
--- a/demo/crash/README.md
+++ b/demo/crash/README.md
@@ -21,11 +21,7 @@ s7 的字符是标记立即数，`s7_string` 底层 `(T_Str(p))->object.string.s
 
 | 文件 | 触发代码 | 信号 | 根因 |
 |---|---|---|---|
-| p02-hashlib-sha256-char.scm | `(import (liii hashlib)) (sha256 #\a)` | SIGSEGV | 同上 |
 | p03-os-unsetenv-char.scm | `(import (liii os)) (unsetenv #\a)` | SIGSEGV | `os.scm` 的 `unsetenv` 直接透传 `g_unsetenv` |
-
-注：`(liii hashlib)` 的 `sha1`/`sha256`/`md5-by-file`/`sha1-by-file`/`sha256-by-file`
-与 `md5` 同构，均裸透传。
 
 ## C 层入口（g_*）崩溃 — os 模块（liii_os.cpp）
 
@@ -49,16 +45,6 @@ s7 的字符是标记立即数，`s7_string` 底层 `(T_Str(p))->object.string.s
 | c23-g_path-read-text-char.scm | `(g_path-read-text #\a)` | SIGSEGV |
 | c24-g_path-read-bytes-char.scm | `(g_path-read-bytes #\a)` | SIGSEGV |
 | c25-g_path-copy-char.scm | `(g_path-copy #\a "x")` | SIGSEGV |
-
-## C 层入口 — hashlib 模块（liii_hashlib.cpp）
-
-| 文件 | 触发代码 | 信号 |
-|---|---|---|
-| c27-g_md5-by-file-char.scm | `(g_md5-by-file #\a)` | SIGSEGV |
-| c28-g_sha1-char.scm | `(g_sha1 #\a)` | SIGSEGV |
-| c29-g_sha1-by-file-char.scm | `(g_sha1-by-file #\a)` | SIGSEGV |
-| c30-g_sha256-char.scm | `(g_sha256 #\a)` | SIGSEGV |
-| c31-g_sha256-by-file-char.scm | `(g_sha256-by-file #\a)` | SIGSEGV |
 
 ## C 层入口 — http 模块（liii_http.cpp）
 
@@ -86,7 +72,8 @@ http 崩溃仅能从根环境 `g_http-*` 直接触发。
   已在 devel/0144.md 修复。
 - `c11-g_listdir-integer.scm`（g_listdir 传入非字符串 abort）
   已在 devel/0145.md 修复。
-- `c26-g_md5-char.scm`（g_md5 传入非字符串段错误，同时修复公开接口 `md5` 的 `p01-hashlib-md5-char.scm`）
+- `c26-g_md5-char.scm` ~ `c31-g_sha256-by-file-char.scm`、`p01`、`p02`
+  （hashlib 模块全部 6 个 C 胶水函数 `g_md5`、`g_md5-by-file`、`g_sha1`、`g_sha1-by-file`、`g_sha256`、`g_sha256-by-file` 及公开包装传入非字符串段错误）
   已在 devel/0147.md 修复。
 
 ## 仍然有效的旧发现

--- a/demo/crash/README.md
+++ b/demo/crash/README.md
@@ -1,7 +1,6 @@
 # demo/crash — 让 bin/gf 崩溃的 Scheme 代码片段
 
-每个文件都是一条可以让 `bin/gf`（Goldfish Scheme v18.11.30, s7 11.5）进程
-异常终止的最小片段。验证方式：
+每个文件都是一条可以让 `bin/gf` 进程异常终止的最小片段。验证方式：
 
 ```bash
 bin/gf demo/crash/<文件名>; echo "exit=$?"
@@ -9,39 +8,106 @@ bin/gf demo/crash/<文件名>; echo "exit=$?"
 # 已中止:   exit=134 (SIGABRT, C++ 未捕获异常)
 ```
 
-每个片段均已 3 次重复验证稳定复现。
+每个片段均已复现验证稳定崩溃（第三轮扫描的 30 个新片段为逐个复跑验证）。
 
-历史条目：
-- `h01-os-call-public-integer.scm`（os-call 传入非字符串段错误）
-  已在 devel/0142.md 修复，修复验证完成后移除。
-- `h02-which-public-integer.scm`（which 传入非字符串 abort）
-  已在 devel/0143.md 修复，修复验证完成后移除。
-- `c09-g_rename-integer.scm`（g_rename 传入非字符串段错误）
-  已在 devel/0144.md 修复，修复验证完成后移除。
-- `c11-g_listdir-integer.scm`（g_listdir 传入非字符串 abort）
-  已在 devel/0145.md 修复，修复验证完成后移除。
+## 关键发现：字符参数是万能触发器
 
-## 已确认的崩溃点
+对一切缺少类型检查的 `s7_string()` 入口，**字符（如 `#\a`）比整数可靠得多**：
+s7 的字符是标记立即数，`s7_string` 底层 `(T_Str(p))->object.string.svalue`
+（`s7_internal.h`，`T_Str(P) = P`）会把立即数当 cell 指针解引用低地址，
+必然 SIGSEGV；而整数是堆 cell，其垃圾值经常碰巧可读，只是静默返回错误结果。
+
+## 公开 API 级崩溃（最严重，包装层裸透传）
 
 | 文件 | 触发代码 | 信号 | 根因 |
 |---|---|---|---|
-| f03-base64-encode-oob-length.scm | `(g_bytevector-base64-encode (make-bytevector 4 65) 1073741824)` | SIGSEGV | `liii_base64.cpp` 的长度参数不校验是否超过 bytevector 实际大小，编码循环按声明长度越界读取 1GB |
+| p02-hashlib-sha256-char.scm | `(import (liii hashlib)) (sha256 #\a)` | SIGSEGV | 同上 |
+| p03-os-unsetenv-char.scm | `(import (liii os)) (unsetenv #\a)` | SIGSEGV | `os.scm` 的 `unsetenv` 直接透传 `g_unsetenv` |
+
+注：`(liii hashlib)` 的 `sha1`/`sha256`/`md5-by-file`/`sha1-by-file`/`sha256-by-file`
+与 `md5` 同构，均裸透传。
+
+## C 层入口（g_*）崩溃 — os 模块（liii_os.cpp）
+
+| 文件 | 触发代码 | 信号 |
+|---|---|---|
+| c13-g_unsetenv-char.scm | `(g_unsetenv #\a)` | SIGSEGV |
+| c14-g_mkdir-char.scm | `(g_mkdir #\a)` | SIGSEGV |
+| c15-g_rmdir-char.scm | `(g_rmdir #\a)` | SIGSEGV |
+| c16-g_remove-file-char.scm | `(g_remove-file #\a)` | SIGSEGV |
+| c17-g_chdir-char.scm | `(g_chdir #\a)` | SIGSEGV |
+| c18-g_access-char.scm | `(g_access #\a 0)` | SIGSEGV |
+| c19-g_setenv-char.scm | `(g_setenv #\a "v")` | SIGSEGV |
+
+## C 层入口 — path 模块（liii_path.cpp）
+
+| 文件 | 触发代码 | 信号 |
+|---|---|---|
+| c20-g_isdir-char.scm | `(g_isdir #\a)` | SIGSEGV |
+| c21-g_isfile-char.scm | `(g_isfile #\a)` | SIGSEGV |
+| c22-g_path-getsize-char.scm | `(g_path-getsize #\a)` | SIGSEGV |
+| c23-g_path-read-text-char.scm | `(g_path-read-text #\a)` | SIGSEGV |
+| c24-g_path-read-bytes-char.scm | `(g_path-read-bytes #\a)` | SIGSEGV |
+| c25-g_path-copy-char.scm | `(g_path-copy #\a "x")` | SIGSEGV |
+
+## C 层入口 — hashlib 模块（liii_hashlib.cpp）
+
+| 文件 | 触发代码 | 信号 |
+|---|---|---|
+| c27-g_md5-by-file-char.scm | `(g_md5-by-file #\a)` | SIGSEGV |
+| c28-g_sha1-char.scm | `(g_sha1 #\a)` | SIGSEGV |
+| c29-g_sha1-by-file-char.scm | `(g_sha1-by-file #\a)` | SIGSEGV |
+| c30-g_sha256-char.scm | `(g_sha256 #\a)` | SIGSEGV |
+| c31-g_sha256-by-file-char.scm | `(g_sha256-by-file #\a)` | SIGSEGV |
+
+## C 层入口 — http 模块（liii_http.cpp）
+
+| 文件 | 触发代码 | 信号 | 根因 |
+|---|---|---|---|
+| c32-g_http-head-integer.scm | `(g_http-head 42)` | SIGABRT | url 未检查，垃圾/空指针进 `cpr::Url`（std::string） |
+| c33-g_http-get-url-integer.scm | `(g_http-get 42 '() '() '() #f)` | SIGABRT | 同上 |
+| c34-g_http-get-params-badpair.scm | `(g_http-get "http://x/" '((1 . 2)) '() '() #f)` | SIGABRT | `to_cpr_parameters` 对 pair 的 key/value 都不检查，整数→空指针→`std::logic_error` |
+| c35-g_http-get-params-nonpair.scm | `(g_http-get "http://x/" '(42) '() '() #f)` | SIGSEGV | 列表项不是 pair 时 `s7_car` 无检查解引用 |
+| c36-g_http-get-headers-badpair.scm | `(g_http-get "http://x/" '() '((1 . 2)) '() #f)` | SIGABRT | `to_cpr_headers` 同 c34 |
+| c37-g_http-get-proxy-badpair.scm | `(g_http-get "http://x/" '() '() '((1 . 2)) #f)` | SIGABRT | `to_cpr_proxies` 同 c34 |
+| c38-g_http-post-url-integer.scm | `(g_http-post 42 "b" ...)` | SIGSEGV | url 未检查 |
+| c39-g_http-post-body-integer.scm | `(g_http-post "http://x/" 42 ...)` | SIGSEGV | body 未检查 |
+
+注：`(liii http)` 公开包装有完整类型检查（`http-require-string` 等），
+http 崩溃仅能从根环境 `g_http-*` 直接触发。
+
+## 历史条目（已修复并移除）
+
+- `h01-os-call-public-integer.scm`（os-call 传入非字符串段错误）
+  已在 devel/0142.md 修复。
+- `h02-which-public-integer.scm`（which 传入非字符串 abort）
+  已在 devel/0143.md 修复，错误类型统一为 `(liii error)` 的 type-error。
+- `c09-g_rename-integer.scm`（g_rename 传入非字符串段错误）
+  已在 devel/0144.md 修复。
+- `c11-g_listdir-integer.scm`（g_listdir 传入非字符串 abort）
+  已在 devel/0145.md 修复。
+- `c26-g_md5-char.scm`（g_md5 传入非字符串段错误，同时修复公开接口 `md5` 的 `p01-hashlib-md5-char.scm`）
+  已在 devel/0147.md 修复。
+
+## 仍然有效的旧发现
+
+| 文件 | 触发代码 | 信号 | 根因 |
+|---|---|---|---|
+| f03-base64-encode-oob-length.scm | `(g_bytevector-base64-encode (make-bytevector 4 65) 1073741824)` | SIGSEGV | 长度参数不校验，编码循环越界读取（修复见 devel/0146.md，待合并） |
 
 ## 涉及的共同根因
 
-1. **C 胶水层不检查参数类型**：`liii_os.cpp`、`liii_path.cpp`、`liii_hashlib.cpp`
-   以及 `goldfish.hpp` 里的 `f_*` 函数大量直接调用 `s7_string(s7_car(args))`。
-   `s7_string` 底层是 `(T_Str(p))->object.string.svalue`（`s7_internal.h:1956`），
-   `T_Str(P) = P`，对非字符串对象等同于把任意对象强转为字符串 cell 解引用。
-   是否崩溃取决于垃圾指针落在哪：`wordexp`/`std::filesystem`/`std::string`
-   这类会立刻解引用/strlen 的路径稳定崩溃；`tb_file_info` 等宽松路径只是静默返回错误值。
-
-2. **长度/容量参数不校验**：`g_bytevector-base64-encode/decode` 的第二参数
-   直接 `s7_integer(s7_cadr(args))`，与实际 bytevector 长度无关。
-
-3. **Scheme 包装层不一致**：`(liii os)` 的 `rename`/`remove`/`listdir` 在包装层
-   做了 `string?` 检查，但 `os-call`、`(liii sys)` 的 `which` 没有做，
-   导致类型错误从 C 层的未定义行为漏出，而不是变成 `type-error`。
+1. **C 胶水层不检查参数类型**：`liii_os.cpp`、`liii_path.cpp`、`liii_hashlib.cpp`、
+   `liii_http.cpp` 及 `goldfish.hpp` 里的 `f_*` 函数大量直接调用
+   `s7_string(s7_car(args))`。`s7_string` 对非字符串对象等同于把对象强转为
+   字符串 cell 解引用：字符（立即数）必崩；整数等堆对象视垃圾指针落点，
+   `std::string`/`wordexp`/`std::filesystem` 等立即 strlen 的路径稳定崩溃，
+   `tb_file_info` 等宽松路径静默返回错误值。
+2. **http 辅助函数对 alist 结构不做检查**：`to_cpr_parameters/headers/proxies`
+   对列表项不检查是否 pair、pair 的两端不检查是否字符串。
+3. **长度/容量参数不校验**：base64 编解码的第二参数与实际 bytevector 长度无关。
+4. **Scheme 包装层防护不一致**：`hashlib.scm` 全部裸透传、`os.scm` 的
+   `unsetenv` 裸透传；而 `http.scm`、`rename`/`listdir`/`mkdir` 等包装层有检查。
 
 ## 测试过但不会崩溃的方面（s7 核心防护完善）
 
@@ -50,9 +116,7 @@ bin/gf demo/crash/<文件名>; echo "exit=$?"
 - 深嵌套/深递归：s7 有栈保护；`(liii json)` 解析器有 10000 层深度限制；
   `(liii njson)` 底层 nlohmann::json 为迭代解析
 - `vector-ref`/`string-ref` 越界、`make-vector -5`、`(string->number "1" 1)` 等均为干净报错
+- `(liii json)` 的 C 层入口（`g_string->json`/`g_json-ref` 等）有类型检查
 - `(liii base64)`、`(liii sort)`、`(liii string-cursor)`、`(liii subprocess)` 的
   C 层入口有 `s7_is_string`/`s7_is_integer` 检查
-
-## 备注
-
-`_readprobe/` 是扫描 reader token 时的临时目录残留，可删除。
+- `(liii os)` 公开包装的 `putenv`/`access`/`mkdir`/`rmdir`/`system` 有检查

--- a/devel/0147.md
+++ b/devel/0147.md
@@ -1,0 +1,42 @@
+# [0147] 修复 g_md5 传入非字符串参数导致 gf 段错误的问题
+
+## 任务相关的代码文件
+- src/liii_hashlib.cpp
+- tests/liii/hashlib/md5-test.scm
+- demo/crash/README.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/hashlib/md5-test.scm
+```
+
+预期：测试输出 `9 correct, 0 failed`。
+
+## 2026-09-08 C++ 层为 g_md5 增加参数类型检查
+
+### What
+
+1. `src/liii_hashlib.cpp` 的 `f_md5` 入口处增加类型守卫：参数不是 string 时抛出
+   `(liii error)` 约定的 `type-error`。
+2. `tests/liii/hashlib/md5-test.scm` 增加参数类型回归测试
+   （`(check-catch 'type-error (md5 #\a))`、`(check-catch 'type-error (md5 123))`）。
+3. 崩溃片段 `demo/crash/c26-g_md5-char.scm`（`(g_md5 #\a)`）及同构公开调用
+   `demo/crash/p01-hashlib-md5-char.scm`（`(md5 #\a)`）修复验证完成后移除。
+
+### Why
+
+`bin/gf demo/crash/c26-g_md5-char.scm`（即 `(g_md5 #\a)`）会让进程段错误
+（SIGSEGV, exit 139）。根因在 C++ 层：`f_md5` 直接 `s7_string(s7_car(args))`，
+对非字符串对象（如字符这种标记立即数）解引用导致非法内存访问，触发段错误。
+
+同时 `(liii hashlib)` 的公开包装 `(define (md5 str) (g_md5 str))` 也是裸透传，
+因此 C++ 胶水层做好防御后，公开包装与根环境直接调用 `g_md5` 都得到保护。
+
+修复前运行新测试会直接段错误（TDD 红灯），修复后 9/9 通过。
+
+### How
+
+与 devel/0144.md / 0145.md 相同的模式：定义辅助函数 `string_type_error`，
+在 C++ 入口先 `s7_is_string` 检查，非字符串抛出 `(liii error)` 约定的 `type-error`，
+可用 `(check-catch 'type-error ...)` 捕获。

--- a/devel/0147.md
+++ b/devel/0147.md
@@ -1,42 +1,54 @@
-# [0147] 修复 g_md5 传入非字符串参数导致 gf 段错误的问题
+# [0147] 修复 hashlib 模块传入非字符串参数导致 gf 段错误的问题
 
 ## 任务相关的代码文件
 - src/liii_hashlib.cpp
 - tests/liii/hashlib/md5-test.scm
+- tests/liii/hashlib/md5-by-file-test.scm
+- tests/liii/hashlib/sha1-test.scm
+- tests/liii/hashlib/sha1-by-file-test.scm
+- tests/liii/hashlib/sha256-test.scm
+- tests/liii/hashlib/sha256-by-file-test.scm
 - demo/crash/README.md
 
 ## 如何测试
 ```bash
 xmake b goldfish
 bin/gf tests/liii/hashlib/md5-test.scm
+bin/gf tests/liii/hashlib/md5-by-file-test.scm
+bin/gf tests/liii/hashlib/sha1-test.scm
+bin/gf tests/liii/hashlib/sha1-by-file-test.scm
+bin/gf tests/liii/hashlib/sha256-test.scm
+bin/gf tests/liii/hashlib/sha256-by-file-test.scm
 ```
 
-预期：测试输出 `9 correct, 0 failed`。
+预期：全部测试通过，0 failed。
 
-## 2026-09-08 C++ 层为 g_md5 增加参数类型检查
+## 2026-09-08 C++ 层为 hashlib 全函数增加参数类型检查
 
 ### What
 
-1. `src/liii_hashlib.cpp` 的 `f_md5` 入口处增加类型守卫：参数不是 string 时抛出
-   `(liii error)` 约定的 `type-error`。
-2. `tests/liii/hashlib/md5-test.scm` 增加参数类型回归测试
-   （`(check-catch 'type-error (md5 #\a))`、`(check-catch 'type-error (md5 123))`）。
-3. 崩溃片段 `demo/crash/c26-g_md5-char.scm`（`(g_md5 #\a)`）及同构公开调用
-   `demo/crash/p01-hashlib-md5-char.scm`（`(md5 #\a)`）修复验证完成后移除。
+1. `src/liii_hashlib.cpp` 的 6 个胶水函数（`f_md5`、`f_md5_file`、`f_sha1`、`f_sha1_file`、`f_sha256`、`f_sha256_file`）
+   入口处增加类型守卫：参数不是 string 时抛出 `(liii error)` 约定的 `type-error`。
+2. 对应 6 个测试文件中增加参数类型回归测试（均使用公开接口，不暴露 `g_*`）：
+   - `tests/liii/hashlib/md5-test.scm`（`md5`）
+   - `tests/liii/hashlib/md5-by-file-test.scm`（`md5-by-file`）
+   - `tests/liii/hashlib/sha1-test.scm`（`sha1`）
+   - `tests/liii/hashlib/sha1-by-file-test.scm`（`sha1-by-file`）
+   - `tests/liii/hashlib/sha256-test.scm`（`sha256`）
+   - `tests/liii/hashlib/sha256-by-file-test.scm`（`sha256-by-file`）
+3. 崩溃片段 `demo/crash/c26-g_md5-char.scm` ~ `demo/crash/c31-g_sha256-by-file-char.scm`
+   及公开接口崩溃片段 `demo/crash/p01-hashlib-md5-char.scm`、`demo/crash/p02-hashlib-sha256-char.scm`
+   修复验证完成后全部移除。
 
 ### Why
 
-`bin/gf demo/crash/c26-g_md5-char.scm`（即 `(g_md5 #\a)`）会让进程段错误
-（SIGSEGV, exit 139）。根因在 C++ 层：`f_md5` 直接 `s7_string(s7_car(args))`，
-对非字符串对象（如字符这种标记立即数）解引用导致非法内存访问，触发段错误。
+hashlib 模块的 6 个 C 胶水函数直接 `s7_string(s7_car(args))`，对非字符串对象
+（如字符这种标记立即数）解引用导致非法内存访问，触发 SIGSEGV 段错误（exit 139）。
 
-同时 `(liii hashlib)` 的公开包装 `(define (md5 str) (g_md5 str))` 也是裸透传，
-因此 C++ 胶水层做好防御后，公开包装与根环境直接调用 `g_md5` 都得到保护。
-
-修复前运行新测试会直接段错误（TDD 红灯），修复后 9/9 通过。
+同时 `(liii hashlib)` 的公开包装全部直接裸透传 `g_*`，因此在 C++ 胶水层做好防御后，
+公开包装与根环境直接调用 `g_*` 均得到完整保护，统一抛出符合规范的 `type-error`。
 
 ### How
 
-与 devel/0144.md / 0145.md 相同的模式：定义辅助函数 `string_type_error`，
-在 C++ 入口先 `s7_is_string` 检查，非字符串抛出 `(liii error)` 约定的 `type-error`，
-可用 `(check-catch 'type-error ...)` 捕获。
+定义辅助函数 `string_type_error`，在 C++ 入口先 `s7_is_string` 检查，非字符串抛出
+`(liii error)` 约定的 `type-error`，可用 `(check-catch 'type-error ...)` 捕获。

--- a/src/liii_hashlib.cpp
+++ b/src/liii_hashlib.cpp
@@ -19,6 +19,11 @@
 
 namespace goldfish {
 
+inline s7_pointer
+string_type_error (s7_scheme* sc, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, "type-error"), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
 static void
 glue_define (s7_scheme* sc, const char* name, const char* desc, s7_function f, s7_int required, s7_int optional) {
   s7_pointer cur_env= s7_curlet (sc);
@@ -110,7 +115,11 @@ sha_file_to_hex (const char* path, tb_size_t mode, tb_size_t digest_size, tb_cha
 
 static s7_pointer
 f_md5 (s7_scheme* sc, s7_pointer args) {
-  const char* search_string= s7_string (s7_car (args));
+  s7_pointer  str_arg      = s7_car (args);
+  if (!s7_is_string (str_arg)) {
+    return string_type_error (sc, "md5: parameter must be a string", str_arg);
+  }
+  const char* search_string= s7_string (str_arg);
   tb_size_t   len          = tb_strlen (search_string);
   tb_byte_t   digest[16];
   tb_char_t   hex_output[33]= {0};

--- a/src/liii_hashlib.cpp
+++ b/src/liii_hashlib.cpp
@@ -115,7 +115,7 @@ sha_file_to_hex (const char* path, tb_size_t mode, tb_size_t digest_size, tb_cha
 
 static s7_pointer
 f_md5 (s7_scheme* sc, s7_pointer args) {
-  s7_pointer  str_arg      = s7_car (args);
+  s7_pointer str_arg= s7_car (args);
   if (!s7_is_string (str_arg)) {
     return string_type_error (sc, "md5: parameter must be a string", str_arg);
   }
@@ -143,7 +143,7 @@ glue_md5 (s7_scheme* sc) {
 
 static s7_pointer
 f_md5_file (s7_scheme* sc, s7_pointer args) {
-  s7_pointer  path_arg      = s7_car (args);
+  s7_pointer path_arg= s7_car (args);
   if (!s7_is_string (path_arg)) {
     return string_type_error (sc, "md5-by-file: path must be a string", path_arg);
   }
@@ -164,7 +164,7 @@ glue_md5_file (s7_scheme* sc) {
 
 static s7_pointer
 f_sha1 (s7_scheme* sc, s7_pointer args) {
-  s7_pointer  str_arg      = s7_car (args);
+  s7_pointer str_arg= s7_car (args);
   if (!s7_is_string (str_arg)) {
     return string_type_error (sc, "sha1: parameter must be a string", str_arg);
   }
@@ -192,7 +192,7 @@ glue_sha1 (s7_scheme* sc) {
 
 static s7_pointer
 f_sha1_file (s7_scheme* sc, s7_pointer args) {
-  s7_pointer  path_arg      = s7_car (args);
+  s7_pointer path_arg= s7_car (args);
   if (!s7_is_string (path_arg)) {
     return string_type_error (sc, "sha1-by-file: path must be a string", path_arg);
   }
@@ -213,7 +213,7 @@ glue_sha1_file (s7_scheme* sc) {
 
 static s7_pointer
 f_sha256 (s7_scheme* sc, s7_pointer args) {
-  s7_pointer  str_arg      = s7_car (args);
+  s7_pointer str_arg= s7_car (args);
   if (!s7_is_string (str_arg)) {
     return string_type_error (sc, "sha256: parameter must be a string", str_arg);
   }
@@ -241,7 +241,7 @@ glue_sha256 (s7_scheme* sc) {
 
 static s7_pointer
 f_sha256_file (s7_scheme* sc, s7_pointer args) {
-  s7_pointer  path_arg      = s7_car (args);
+  s7_pointer path_arg= s7_car (args);
   if (!s7_is_string (path_arg)) {
     return string_type_error (sc, "sha256-by-file: path must be a string", path_arg);
   }

--- a/src/liii_hashlib.cpp
+++ b/src/liii_hashlib.cpp
@@ -143,7 +143,11 @@ glue_md5 (s7_scheme* sc) {
 
 static s7_pointer
 f_md5_file (s7_scheme* sc, s7_pointer args) {
-  const char* path          = s7_string (s7_car (args));
+  s7_pointer  path_arg      = s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "md5-by-file: path must be a string", path_arg);
+  }
+  const char* path          = s7_string (path_arg);
   tb_char_t   hex_output[33]= {0};
   if (!md5_file_to_hex (path, hex_output)) {
     return s7_make_boolean (sc, false);
@@ -160,7 +164,11 @@ glue_md5_file (s7_scheme* sc) {
 
 static s7_pointer
 f_sha1 (s7_scheme* sc, s7_pointer args) {
-  const char* search_string= s7_string (s7_car (args));
+  s7_pointer  str_arg      = s7_car (args);
+  if (!s7_is_string (str_arg)) {
+    return string_type_error (sc, "sha1: parameter must be a string", str_arg);
+  }
+  const char* search_string= s7_string (str_arg);
   tb_size_t   len          = tb_strlen (search_string);
   tb_byte_t   digest[20];
   tb_char_t   hex_output[41]= {0};
@@ -184,7 +192,11 @@ glue_sha1 (s7_scheme* sc) {
 
 static s7_pointer
 f_sha1_file (s7_scheme* sc, s7_pointer args) {
-  const char* path          = s7_string (s7_car (args));
+  s7_pointer  path_arg      = s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "sha1-by-file: path must be a string", path_arg);
+  }
+  const char* path          = s7_string (path_arg);
   tb_char_t   hex_output[41]= {0};
   if (!sha_file_to_hex (path, 160, 20, hex_output)) {
     return s7_make_boolean (sc, false);
@@ -201,7 +213,11 @@ glue_sha1_file (s7_scheme* sc) {
 
 static s7_pointer
 f_sha256 (s7_scheme* sc, s7_pointer args) {
-  const char* search_string= s7_string (s7_car (args));
+  s7_pointer  str_arg      = s7_car (args);
+  if (!s7_is_string (str_arg)) {
+    return string_type_error (sc, "sha256: parameter must be a string", str_arg);
+  }
+  const char* search_string= s7_string (str_arg);
   tb_size_t   len          = tb_strlen (search_string);
   tb_byte_t   digest[32];
   tb_char_t   hex_output[65]= {0};
@@ -225,7 +241,11 @@ glue_sha256 (s7_scheme* sc) {
 
 static s7_pointer
 f_sha256_file (s7_scheme* sc, s7_pointer args) {
-  const char* path          = s7_string (s7_car (args));
+  s7_pointer  path_arg      = s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "sha256-by-file: path must be a string", path_arg);
+  }
+  const char* path          = s7_string (path_arg);
   tb_char_t   hex_output[65]= {0};
   if (!sha_file_to_hex (path, 256, 32, hex_output)) {
     return s7_make_boolean (sc, false);

--- a/tests/liii/hashlib/md5-by-file-test.scm
+++ b/tests/liii/hashlib/md5-by-file-test.scm
@@ -43,6 +43,8 @@
   (delete-file tmp-file)
 ) ;let
 
-
+;; 异常情况测试：非字符串参数
+(check-catch 'type-error (md5-by-file #\a))
+(check-catch 'type-error (md5-by-file 123))
 
 (check-report)

--- a/tests/liii/hashlib/md5-test.scm
+++ b/tests/liii/hashlib/md5-test.scm
@@ -41,6 +41,8 @@
 (check (md5 "!@#$%^&*()") => "05b28d17a7b6e7024b6e5d8cc43a8bf7")
 (check (md5 "Hello") => "8b1a9953c4611296a827abf8c47804d7")
 
-
+;; 异常情况测试：非字符串参数
+(check-catch 'type-error (md5 #\a))
+(check-catch 'type-error (md5 123))
 
 (check-report)

--- a/tests/liii/hashlib/sha1-by-file-test.scm
+++ b/tests/liii/hashlib/sha1-by-file-test.scm
@@ -43,6 +43,8 @@
   (delete-file tmp-file)
 ) ;let
 
-
+;; 异常情况测试：非字符串参数
+(check-catch 'type-error (sha1-by-file #\a))
+(check-catch 'type-error (sha1-by-file 123))
 
 (check-report)

--- a/tests/liii/hashlib/sha1-test.scm
+++ b/tests/liii/hashlib/sha1-test.scm
@@ -41,6 +41,8 @@
 (check (sha1 "!@#$%^&*()") => "bf24d65c9bb05b9b814a966940bcfa50767c8a8d")
 (check (sha1 "Hello") => "f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0")
 
-
+;; 异常情况测试：非字符串参数
+(check-catch 'type-error (sha1 #\a))
+(check-catch 'type-error (sha1 123))
 
 (check-report)

--- a/tests/liii/hashlib/sha256-by-file-test.scm
+++ b/tests/liii/hashlib/sha256-by-file-test.scm
@@ -57,6 +57,8 @@
   ) ;when
 ) ;let*
 
-
+;; 异常情况测试：非字符串参数
+(check-catch 'type-error (sha256-by-file #\a))
+(check-catch 'type-error (sha256-by-file 123))
 
 (check-report)

--- a/tests/liii/hashlib/sha256-test.scm
+++ b/tests/liii/hashlib/sha256-test.scm
@@ -59,6 +59,8 @@
   "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969"
 ) ;check
 
-
+;; 异常情况测试：非字符串参数
+(check-catch 'type-error (sha256 #\a))
+(check-catch 'type-error (sha256 123))
 
 (check-report)


### PR DESCRIPTION
详见 devel/0147.md