### PR TITLE
[0148] C++ 层为 os 模块胶水函数增加参数类型检查，修复非字符串参数导致的段错误

### DIFF
--- a/demo/crash/README.md
+++ b/demo/crash/README.md
@@ -17,24 +17,6 @@ s7 的字符是标记立即数，`s7_string` 底层 `(T_Str(p))->object.string.s
 （`s7_internal.h`，`T_Str(P) = P`）会把立即数当 cell 指针解引用低地址，
 必然 SIGSEGV；而整数是堆 cell，其垃圾值经常碰巧可读，只是静默返回错误结果。
 
-## 公开 API 级崩溃（最严重，包装层裸透传）
-
-| 文件 | 触发代码 | 信号 | 根因 |
-|---|---|---|---|
-| p03-os-unsetenv-char.scm | `(import (liii os)) (unsetenv #\a)` | SIGSEGV | `os.scm` 的 `unsetenv` 直接透传 `g_unsetenv` |
-
-## C 层入口（g_*）崩溃 — os 模块（liii_os.cpp）
-
-| 文件 | 触发代码 | 信号 |
-|---|---|---|
-| c13-g_unsetenv-char.scm | `(g_unsetenv #\a)` | SIGSEGV |
-| c14-g_mkdir-char.scm | `(g_mkdir #\a)` | SIGSEGV |
-| c15-g_rmdir-char.scm | `(g_rmdir #\a)` | SIGSEGV |
-| c16-g_remove-file-char.scm | `(g_remove-file #\a)` | SIGSEGV |
-| c17-g_chdir-char.scm | `(g_chdir #\a)` | SIGSEGV |
-| c18-g_access-char.scm | `(g_access #\a 0)` | SIGSEGV |
-| c19-g_setenv-char.scm | `(g_setenv #\a "v")` | SIGSEGV |
-
 ## C 层入口 — path 模块（liii_path.cpp）
 
 | 文件 | 触发代码 | 信号 |
@@ -72,6 +54,9 @@ http 崩溃仅能从根环境 `g_http-*` 直接触发。
   已在 devel/0144.md 修复。
 - `c11-g_listdir-integer.scm`（g_listdir 传入非字符串 abort）
   已在 devel/0145.md 修复。
+- `c13-g_unsetenv-char.scm` ~ `c19-g_setenv-char.scm`、`p03-os-unsetenv-char.scm`
+  （os 模块 C 胶水函数 `g_unsetenv`、`g_mkdir`、`g_rmdir`、`g_remove-file`、`g_chdir`、`g_access`、`g_setenv` 及公开包装传入非字符串段错误）
+  已在 devel/0148.md 修复。
 - `c26-g_md5-char.scm` ~ `c31-g_sha256-by-file-char.scm`、`p01`、`p02`
   （hashlib 模块全部 6 个 C 胶水函数 `g_md5`、`g_md5-by-file`、`g_sha1`、`g_sha1-by-file`、`g_sha256`、`g_sha256-by-file` 及公开包装传入非字符串段错误）
   已在 devel/0147.md 修复。

--- a/devel/0148.md
+++ b/devel/0148.md
@@ -1,0 +1,54 @@
+# [0148] 修复 os 模块传入非字符串参数导致 gf 段错误的问题 (c13 ~ c19)
+
+## 任务相关的代码文件
+- src/liii_os.cpp
+- tests/liii/os/access-test.scm
+- tests/liii/os/chdir-test.scm
+- tests/liii/os/mkdir-test.scm
+- tests/liii/os/putenv-test.scm
+- tests/liii/os/remove-test.scm
+- tests/liii/os/rmdir-test.scm
+- tests/liii/os/unsetenv-test.scm
+- demo/crash/README.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/os/access-test.scm
+bin/gf tests/liii/os/chdir-test.scm
+bin/gf tests/liii/os/mkdir-test.scm
+bin/gf tests/liii/os/putenv-test.scm
+bin/gf tests/liii/os/remove-test.scm
+bin/gf tests/liii/os/rmdir-test.scm
+bin/gf tests/liii/os/unsetenv-test.scm
+```
+
+预期：全部测试通过，0 failed。
+
+## 2026-09-08 C++ 层为 os 模块胶水函数增加参数类型检查
+
+### What
+
+1. `src/liii_os.cpp` 的胶水函数（`f_system`、`f_access`、`f_set_environment_variable`、`f_unset_environment_variable`、`f_mkdir`、`f_rmdir`、`f_remove_file`、`f_chdir`）入口处增加类型守卫：
+   - 字符串参数不是 string 时抛出 `(liii error)` 约定的 `type-error`
+   - `f_access` 的 `mode` 参数不是 integer 时抛出 `type-error`
+2. 对应测试文件中增加参数类型回归测试（均使用公开接口，不暴露 `g_*`）：
+   - `tests/liii/os/access-test.scm`（`access`）
+   - `tests/liii/os/chdir-test.scm`（`chdir`）
+   - `tests/liii/os/mkdir-test.scm`（`mkdir`）
+   - `tests/liii/os/putenv-test.scm`（`putenv`）
+   - `tests/liii/os/remove-test.scm`（`remove`）
+   - `tests/liii/os/rmdir-test.scm`（`rmdir`）
+   - `tests/liii/os/unsetenv-test.scm`（`unsetenv`）
+3. 更新 `demo/crash/README.md`，将已修复的 `c13 ~ c19` 和公开接口崩溃片段 `p03` 移入“历史条目（已修复并移除）”。
+
+### Why
+
+`liii_os.cpp` 中的底层胶水函数直接通过 `s7_string(s7_car(args))` 获取 C 字符串，对非字符串对象（如字符这种标记立即数）强转解引用会导致非法内存访问，触发 SIGSEGV 段错误（exit 139）。
+其中 `unsetenv` 等公开包装由于直接裸透传 `g_unsetenv`，导致在公开 API 层面也会崩溃（p03）。
+
+在 C++ 胶水层做好类型防御后，公开包装与根环境直接调用 `g_*` 均得到完整保护，统一抛出符合规范的 `type-error`。
+
+### How
+
+复用 `string_type_error` 辅助函数，在各函数入口通过 `s7_is_string` 和 `s7_is_integer` 检查参数类型。若类型不匹配，通过 `s7_error` 抛出 `(liii error)` 约定的 `type-error`，并在 Scheme 端可通过 `(check-catch 'type-error ...)` 捕获。

--- a/src/liii_os.cpp
+++ b/src/liii_os.cpp
@@ -151,7 +151,11 @@ glue_os_call (s7_scheme* sc) {
 
 static s7_pointer
 f_system (s7_scheme* sc, s7_pointer args) {
-  const char* cmd_c= s7_string (s7_car (args));
+  s7_pointer cmd_arg= s7_car (args);
+  if (!s7_is_string (cmd_arg)) {
+    return string_type_error (sc, "system: command must be a string", cmd_arg);
+  }
+  const char* cmd_c= s7_string (cmd_arg);
   int         ret  = (int) std::system (cmd_c);
   return s7_make_integer (sc, ret);
 }
@@ -165,8 +169,16 @@ glue_system (s7_scheme* sc) {
 
 static s7_pointer
 f_access (s7_scheme* sc, s7_pointer args) {
-  const char* path_c= s7_string (s7_car (args));
-  int         mode  = s7_integer ((s7_cadr (args)));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "access: path must be a string", path_arg);
+  }
+  s7_pointer mode_arg= s7_cadr (args);
+  if (!s7_is_integer (mode_arg)) {
+    return string_type_error (sc, "access: mode must be an integer", mode_arg);
+  }
+  const char* path_c= s7_string (path_arg);
+  int         mode  = s7_integer (mode_arg);
   bool        ret   = false;
   if (mode == 0) {
     tb_file_info_t info;
@@ -188,8 +200,16 @@ glue_access (s7_scheme* sc) {
 
 static s7_pointer
 f_set_environment_variable (s7_scheme* sc, s7_pointer args) {
-  const char* key  = s7_string (s7_car (args));
-  const char* value= s7_string (s7_cadr (args));
+  s7_pointer key_arg= s7_car (args);
+  if (!s7_is_string (key_arg)) {
+    return string_type_error (sc, "setenv: key must be a string", key_arg);
+  }
+  s7_pointer value_arg= s7_cadr (args);
+  if (!s7_is_string (value_arg)) {
+    return string_type_error (sc, "setenv: value must be a string", value_arg);
+  }
+  const char* key  = s7_string (key_arg);
+  const char* value= s7_string (value_arg);
   return s7_make_boolean (sc, tb_environment_set (key, value));
 }
 
@@ -202,7 +222,11 @@ glue_setenv (s7_scheme* sc) {
 
 static s7_pointer
 f_unset_environment_variable (s7_scheme* sc, s7_pointer args) {
-  const char* env_name= s7_string (s7_car (args));
+  s7_pointer env_arg= s7_car (args);
+  if (!s7_is_string (env_arg)) {
+    return string_type_error (sc, "unsetenv: key must be a string", env_arg);
+  }
+  const char* env_name= s7_string (env_arg);
   return s7_make_boolean (sc, tb_environment_remove (env_name));
 }
 
@@ -229,7 +253,11 @@ glue_os_temp_dir (s7_scheme* sc) {
 
 static s7_pointer
 f_mkdir (s7_scheme* sc, s7_pointer args) {
-  const char* dir_c= s7_string (s7_car (args));
+  s7_pointer dir_arg= s7_car (args);
+  if (!s7_is_string (dir_arg)) {
+    return string_type_error (sc, "mkdir: path must be a string", dir_arg);
+  }
+  const char* dir_c= s7_string (dir_arg);
   return s7_make_boolean (sc, tb_directory_create (dir_c));
 }
 
@@ -242,7 +270,11 @@ glue_mkdir (s7_scheme* sc) {
 
 static s7_pointer
 f_rmdir (s7_scheme* sc, s7_pointer args) {
-  const char* dir_c= s7_string (s7_car (args));
+  s7_pointer dir_arg= s7_car (args);
+  if (!s7_is_string (dir_arg)) {
+    return string_type_error (sc, "rmdir: path must be a string", dir_arg);
+  }
+  const char* dir_c= s7_string (dir_arg);
   return s7_make_boolean (sc, tb_directory_remove (dir_c));
 }
 
@@ -255,7 +287,11 @@ glue_rmdir (s7_scheme* sc) {
 
 static s7_pointer
 f_remove_file (s7_scheme* sc, s7_pointer args) {
-  const char* path   = s7_string (s7_car (args));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "remove-file: path must be a string", path_arg);
+  }
+  const char* path   = s7_string (path_arg);
   bool        success= tb_file_remove (path);
   return s7_make_boolean (sc, success);
 }
@@ -296,7 +332,11 @@ glue_rename (s7_scheme* sc) {
 
 static s7_pointer
 f_chdir (s7_scheme* sc, s7_pointer args) {
-  const char* dir_c= s7_string (s7_car (args));
+  s7_pointer dir_arg= s7_car (args);
+  if (!s7_is_string (dir_arg)) {
+    return string_type_error (sc, "chdir: path must be a string", dir_arg);
+  }
+  const char* dir_c= s7_string (dir_arg);
   return s7_make_boolean (sc, tb_directory_current_set (dir_c));
 }
 

--- a/tests/liii/os/access-test.scm
+++ b/tests/liii/os/access-test.scm
@@ -25,6 +25,11 @@
 ;; boolean?
 ;; 如果有指定权限返回 #t，否则返回 #f。
 ;;
+;; 错误
+;; ----
+;; type-error
+;; 当 path 不是字符串时抛出错误。
+;;
 ;; 说明
 ;; ----
 ;; 检查当前进程对指定文件的访问权限。
@@ -37,6 +42,11 @@
   (check-false (access "/root" 'W_OK))
   (check-true (access (executable) 'X_OK))
 ) ;when
+
+
+;; ; 错误测试
+(check-catch 'type-error (access #\a 'F_OK))
+(check-catch 'type-error (access 123 'F_OK))
 
 
 (check-report)

--- a/tests/liii/os/chdir-test.scm
+++ b/tests/liii/os/chdir-test.scm
@@ -23,6 +23,9 @@
 ;;
 ;; 错误
 ;; ----
+;; type-error
+;; 当 path 不是字符串时抛出错误。
+;;
 ;; file-not-found-error
 ;; 当目录不存在时抛出错误。
 
@@ -59,6 +62,8 @@
 
 
 ;; ; 错误测试
+(check-catch 'type-error (chdir #\a))
+(check-catch 'type-error (chdir 123))
 (check-catch 'file-not-found-error (chdir "/nonexistent/directory"))
 
 

--- a/tests/liii/os/mkdir-test.scm
+++ b/tests/liii/os/mkdir-test.scm
@@ -23,6 +23,9 @@
 ;;
 ;; 错误
 ;; ----
+;; type-error
+;; 当 path 不是字符串时抛出错误。
+;;
 ;; file-exists-error
 ;; 当目录已存在时抛出错误。
 ;;
@@ -54,6 +57,11 @@
     (rmdir "/tmp/test_124")
   ) ;when
 ) ;when
+
+
+;; ; 错误测试
+(check-catch 'type-error (mkdir #\a))
+(check-catch 'type-error (mkdir 123))
 
 
 (check-report)

--- a/tests/liii/os/putenv-test.scm
+++ b/tests/liii/os/putenv-test.scm
@@ -38,6 +38,8 @@
 ;; ; 错误测试
 (check-catch 'type-error (putenv 123 "abc"))
 (check-catch 'type-error (putenv "ABC" 123))
+(check-catch 'type-error (putenv #\a "abc"))
+(check-catch 'type-error (putenv "ABC" #\a))
 
 
 (check-report)

--- a/tests/liii/os/remove-test.scm
+++ b/tests/liii/os/remove-test.scm
@@ -51,6 +51,7 @@
 
 ;; ; 错误测试
 (check-catch 'type-error (remove 123))
+(check-catch 'type-error (remove #\a))
 (check-catch 'file-not-found-error (remove "/nonexistent/file"))
 
 

--- a/tests/liii/os/rmdir-test.scm
+++ b/tests/liii/os/rmdir-test.scm
@@ -21,6 +21,11 @@
 ;; boolean?
 ;; 成功返回 #t。
 ;;
+;; 错误
+;; ----
+;; type-error
+;; 当 path 不是字符串时抛出错误。
+;;
 ;; 说明
 ;; ----
 ;; 只能删除空目录，如果目录不为空会失败。
@@ -43,6 +48,11 @@
   (check-true (rmdir test-dir))
   (check-false (file-exists? test-dir))
 ) ;let*
+
+
+;; ; 错误测试
+(check-catch 'type-error (rmdir #\a))
+(check-catch 'type-error (rmdir 123))
 
 
 (check-report)

--- a/tests/liii/os/unsetenv-test.scm
+++ b/tests/liii/os/unsetenv-test.scm
@@ -21,6 +21,11 @@
 ;; boolean?
 ;; 成功返回 #t。
 ;;
+;; 错误
+;; ----
+;; type-error
+;; 当 key 不是字符串时抛出错误。
+;;
 ;; 说明
 ;; ----
 ;; 删除指定的环境变量，如果变量不存在则不执行任何操作。
@@ -35,6 +40,11 @@
 
 ;; ; 测试删除不存在的变量
 (check-true (unsetenv "NONEXISTENT_VAR_12345"))
+
+
+;; ; 错误测试
+(check-catch 'type-error (unsetenv #\a))
+(check-catch 'type-error (unsetenv 123))
 
 
 (check-report)


### PR DESCRIPTION
详见 devel/0148.md

- 为 `src/liii_os.cpp` 的胶水函数（`f_unset_environment_variable`、`f_mkdir`、`f_rmdir`、`f_remove_file`、`f_chdir`、`f_system`、`f_access`、`f_set_environment_variable`）增加参数类型检查
- 修复非字符串参数导致的 SIGSEGV 崩溃（c13 ~ c19、p03）
- 补充各函数参数类型错误单元测试
- 更新 demo/crash/README.md