### PR TITLE
[0150] C++ 层为 path 模块胶水函数增加参数类型检查，修复非字符串参数导致的段错误

### DIFF
--- a/demo/crash/README.md
+++ b/demo/crash/README.md
@@ -17,17 +17,6 @@ s7 的字符是标记立即数，`s7_string` 底层 `(T_Str(p))->object.string.s
 （`s7_internal.h`，`T_Str(P) = P`）会把立即数当 cell 指针解引用低地址，
 必然 SIGSEGV；而整数是堆 cell，其垃圾值经常碰巧可读，只是静默返回错误结果。
 
-## C 层入口 — path 模块（liii_path.cpp）
-
-| 文件 | 触发代码 | 信号 |
-|---|---|---|
-| c20-g_isdir-char.scm | `(g_isdir #\a)` | SIGSEGV |
-| c21-g_isfile-char.scm | `(g_isfile #\a)` | SIGSEGV |
-| c22-g_path-getsize-char.scm | `(g_path-getsize #\a)` | SIGSEGV |
-| c23-g_path-read-text-char.scm | `(g_path-read-text #\a)` | SIGSEGV |
-| c24-g_path-read-bytes-char.scm | `(g_path-read-bytes #\a)` | SIGSEGV |
-| c25-g_path-copy-char.scm | `(g_path-copy #\a "x")` | SIGSEGV |
-
 ## C 层入口 — http 模块（liii_http.cpp）
 
 | 文件 | 触发代码 | 信号 | 根因 |
@@ -60,6 +49,9 @@ http 崩溃仅能从根环境 `g_http-*` 直接触发。
 - `c26-g_md5-char.scm` ~ `c31-g_sha256-by-file-char.scm`、`p01`、`p02`
   （hashlib 模块全部 6 个 C 胶水函数 `g_md5`、`g_md5-by-file`、`g_sha1`、`g_sha1-by-file`、`g_sha256`、`g_sha256-by-file` 及公开包装传入非字符串段错误）
   已在 devel/0147.md 修复。
+- `c20-g_isdir-char.scm` ~ `c25-g_path-copy-char.scm`
+  （path 模块全部 C 胶水函数 `g_isdir`、`g_isfile`、`g_path-getsize`、`g_path-read-text`、`g_path-read-bytes`、`g_path-write-text`、`g_path-write-bytes`、`g_path-append-text`、`g_path-touch`、`g_path-copy` 及公开包装传入非字符串/非法类型参数段错误）
+  已在 devel/0150.md 修复。
 
 ## 仍然有效的旧发现
 

--- a/devel/0150.md
+++ b/devel/0150.md
@@ -1,0 +1,64 @@
+# [0150] 修复 path 模块传入非字符串/非法参数导致 gf 段错误的问题 (c20 ~ c25)
+
+## 任务相关的代码文件
+- src/liii_path.cpp
+- goldfish/liii/path.scm
+- tests/liii/path/path-dir-p-test.scm
+- tests/liii/path/path-file-p-test.scm
+- tests/liii/path/path-getsize-test.scm
+- tests/liii/path/path-read-text-test.scm
+- tests/liii/path/path-read-bytes-test.scm
+- tests/liii/path/path-write-text-test.scm
+- tests/liii/path/path-write-bytes-test.scm
+- tests/liii/path/path-append-text-test.scm
+- tests/liii/path/path-touch-test.scm
+- tests/liii/path/path-copy-test.scm
+- demo/crash/README.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/path/path-dir-p-test.scm
+bin/gf tests/liii/path/path-file-p-test.scm
+bin/gf tests/liii/path/path-getsize-test.scm
+bin/gf tests/liii/path/path-read-text-test.scm
+bin/gf tests/liii/path/path-read-bytes-test.scm
+bin/gf tests/liii/path/path-write-text-test.scm
+bin/gf tests/liii/path/path-write-bytes-test.scm
+bin/gf tests/liii/path/path-append-text-test.scm
+bin/gf tests/liii/path/path-touch-test.scm
+bin/gf tests/liii/path/path-copy-test.scm
+```
+
+预期：全部测试通过，0 failed。
+
+## 2026-09-08 C++ 层为 path 模块胶水函数增加参数类型检查
+
+### What
+
+1. `src/liii_path.cpp` 中的全部 10 个胶水函数（`f_isdir`、`f_isfile`、`f_path_getsize`、`f_path_read_text`、`f_path_read_bytes`、`f_path_write_text`、`f_path_write_bytes`、`f_path_append_text`、`f_path_touch`、`f_path_copy`）入口处增加类型守卫：
+   - 字符串参数不是 string 时抛出 `(liii error)` 约定的 `type-error`
+   - `f_path_write_bytes` 的 bytevector 参数不是 bytevector 时抛出 `type-error`
+2. `goldfish/liii/path.scm` 中为 `path-append-text` 补齐对 `content` 参数的 `(string? content)` 检查。
+3. 对应 10 个测试文件中增加参数类型回归测试（均使用公开接口）：
+   - `tests/liii/path/path-dir-p-test.scm`（`path-dir?`）
+   - `tests/liii/path/path-file-p-test.scm`（`path-file?`）
+   - `tests/liii/path/path-getsize-test.scm`（`path-getsize`）
+   - `tests/liii/path/path-read-text-test.scm`（`path-read-text`）
+   - `tests/liii/path/path-read-bytes-test.scm`（`path-read-bytes`）
+   - `tests/liii/path/path-write-text-test.scm`（`path-write-text`）
+   - `tests/liii/path/path-write-bytes-test.scm`（`path-write-bytes`）
+   - `tests/liii/path/path-append-text-test.scm`（`path-append-text`）
+   - `tests/liii/path/path-touch-test.scm`（`path-touch`）
+   - `tests/liii/path/path-copy-test.scm`（`path-copy`）
+4. 更新 `demo/crash/README.md`，将已修复的 `c20 ~ c25` 移入“历史条目（已修复并移除）”。
+
+### Why
+
+`liii_path.cpp` 中的底层胶水函数直接通过 `s7_string(s7_car(args))` 获取 C 字符串，对非字符串对象（如字符这种标记立即数）强转解引用会导致非法内存访问，触发 SIGSEGV 段错误（exit 139）。
+
+在 C++ 胶水层做好类型防御后，公开包装与根环境直接调用 `g_*` 均得到完整保护，统一抛出符合规范的 `type-error`。
+
+### How
+
+引入 `string_type_error` 辅助函数，在各函数入口通过 `s7_is_string` 和 `s7_is_byte_vector` 检查参数类型。若类型不匹配，通过 `s7_error` 抛出 `(liii error)` 约定的 `type-error`，并在 Scheme 端可通过 `(check-catch 'type-error ...)` 捕获。

--- a/goldfish/liii/path.scm
+++ b/goldfish/liii/path.scm
@@ -924,7 +924,10 @@
 
     ;; ; 追加文本到文件末尾。
     (define (path-append-text p content)
-      (g_path-append-text (path->string p) content)
+      (if (not (string? content))
+        (type-error "path-append-text: content must be string")
+        (g_path-append-text (path->string p) content)
+      ) ;if
     ) ;define
 
     ;; ; 创建空文件(若不存在),已存在则更新访问时间。

--- a/src/liii_path.cpp
+++ b/src/liii_path.cpp
@@ -26,6 +26,12 @@ namespace goldfish {
 
 using std::string;
 
+// 抛出 (liii error) 约定的 type-error，irritant 为出错的参数
+inline s7_pointer
+string_type_error (s7_scheme* sc, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, "type-error"), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
 inline void
 glue_define (s7_scheme* sc, const char* name, const char* desc, s7_function f, s7_int required, s7_int optional) {
   s7_pointer cur_env= s7_curlet (sc);
@@ -35,7 +41,11 @@ glue_define (s7_scheme* sc, const char* name, const char* desc, s7_function f, s
 
 static s7_pointer
 f_isdir (s7_scheme* sc, s7_pointer args) {
-  const char*    dir_c= s7_string (s7_car (args));
+  s7_pointer dir_arg= s7_car (args);
+  if (!s7_is_string (dir_arg)) {
+    return string_type_error (sc, "isdir: path must be a string", dir_arg);
+  }
+  const char*    dir_c= s7_string (dir_arg);
   tb_file_info_t info;
   bool           ret= false;
   if (tb_file_info (dir_c, &info)) {
@@ -58,7 +68,11 @@ glue_isdir (s7_scheme* sc) {
 
 static s7_pointer
 f_isfile (s7_scheme* sc, s7_pointer args) {
-  const char*    dir_c= s7_string (s7_car (args));
+  s7_pointer dir_arg= s7_car (args);
+  if (!s7_is_string (dir_arg)) {
+    return string_type_error (sc, "isfile: path must be a string", dir_arg);
+  }
+  const char*    dir_c= s7_string (dir_arg);
   tb_file_info_t info;
   bool           ret= false;
   if (tb_file_info (dir_c, &info)) {
@@ -79,7 +93,11 @@ glue_isfile (s7_scheme* sc) {
 
 static s7_pointer
 f_path_getsize (s7_scheme* sc, s7_pointer args) {
-  const char*    path_c= s7_string (s7_car (args));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "path-getsize: path must be a string", path_arg);
+  }
+  const char*    path_c= s7_string (path_arg);
   tb_file_info_t info;
   if (tb_file_info (path_c, &info)) {
     return s7_make_integer (sc, (int) info.size);
@@ -98,7 +116,11 @@ glue_path_getsize (s7_scheme* sc) {
 
 static s7_pointer
 f_path_read_text (s7_scheme* sc, s7_pointer args) {
-  const char* path= s7_string (s7_car (args));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "path-read-text: path must be a string", path_arg);
+  }
+  const char* path= s7_string (path_arg);
   if (!path) {
     return s7_make_boolean (sc, false);
   }
@@ -151,7 +173,11 @@ glue_path_read_text (s7_scheme* sc) {
 
 static s7_pointer
 f_path_read_bytes (s7_scheme* sc, s7_pointer args) {
-  const char* path= s7_string (s7_car (args));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "path-read-bytes: path must be a string", path_arg);
+  }
+  const char* path= s7_string (path_arg);
   if (!path) {
     return s7_make_boolean (sc, false);
   }
@@ -195,12 +221,20 @@ glue_path_read_bytes (s7_scheme* sc) {
 
 static s7_pointer
 f_path_write_text (s7_scheme* sc, s7_pointer args) {
-  const char* path= s7_string (s7_car (args));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "path-write-text: path must be a string", path_arg);
+  }
+  s7_pointer content_arg= s7_cadr (args);
+  if (!s7_is_string (content_arg)) {
+    return string_type_error (sc, "path-write-text: content must be a string", content_arg);
+  }
+  const char* path= s7_string (path_arg);
   if (!path) {
     return s7_make_integer (sc, -1);
   }
 
-  const char* content= s7_string (s7_cadr (args));
+  const char* content= s7_string (content_arg);
   if (!content) {
     return s7_make_integer (sc, -1);
   }
@@ -242,13 +276,16 @@ write content to the file at the given path and return the number of bytes writt
 
 static s7_pointer
 f_path_write_bytes (s7_scheme* sc, s7_pointer args) {
-  const char* path= s7_string (s7_car (args));
-  if (!path) {
-    return s7_make_integer (sc, -1);
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "path-write-bytes: path must be a string", path_arg);
   }
-
   s7_pointer bv= s7_cadr (args);
   if (!s7_is_byte_vector (bv)) {
+    return string_type_error (sc, "path-write-bytes: content must be a bytevector", bv);
+  }
+  const char* path= s7_string (path_arg);
+  if (!path) {
     return s7_make_integer (sc, -1);
   }
 
@@ -290,12 +327,20 @@ write bytevector to the file at the given path in binary mode and return the num
 
 static s7_pointer
 f_path_append_text (s7_scheme* sc, s7_pointer args) {
-  const char* path= s7_string (s7_car (args));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "path-append-text: path must be a string", path_arg);
+  }
+  s7_pointer content_arg= s7_cadr (args);
+  if (!s7_is_string (content_arg)) {
+    return string_type_error (sc, "path-append-text: content must be a string", content_arg);
+  }
+  const char* path= s7_string (path_arg);
   if (!path) {
     return s7_make_integer (sc, -1);
   }
 
-  const char* content= s7_string (s7_cadr (args));
+  const char* content= s7_string (content_arg);
   if (!content) {
     return s7_make_integer (sc, -1);
   }
@@ -337,7 +382,11 @@ append content to the file at the given path and return the number of bytes writ
 
 static s7_pointer
 f_path_touch (s7_scheme* sc, s7_pointer args) {
-  const char* path= s7_string (s7_car (args));
+  s7_pointer path_arg= s7_car (args);
+  if (!s7_is_string (path_arg)) {
+    return string_type_error (sc, "path-touch: path must be a string", path_arg);
+  }
+  const char* path= s7_string (path_arg);
   if (!path) {
     return s7_make_boolean (sc, false);
   }
@@ -361,8 +410,16 @@ glue_path_touch (s7_scheme* sc) {
 
 static s7_pointer
 f_path_copy (s7_scheme* sc, s7_pointer args) {
-  const char* source= s7_string (s7_car (args));
-  const char* target= s7_string (s7_cadr (args));
+  s7_pointer src_arg= s7_car (args);
+  if (!s7_is_string (src_arg)) {
+    return string_type_error (sc, "path-copy: src must be a string", src_arg);
+  }
+  s7_pointer dst_arg= s7_cadr (args);
+  if (!s7_is_string (dst_arg)) {
+    return string_type_error (sc, "path-copy: dst must be a string", dst_arg);
+  }
+  const char* source= s7_string (src_arg);
+  const char* target= s7_string (dst_arg);
 
   if (!source || !target) {
     return s7_make_boolean (sc, false);

--- a/tests/liii/path/path-append-text-test.scm
+++ b/tests/liii/path/path-append-text-test.scm
@@ -42,4 +42,14 @@
   (delete-file (path->string append-missing-file))
 ) ;let
 
+;; 错误处理测试
+(check-catch 'type-error (path-append-text #\a "hello"))
+(check-catch 'type-error (path-append-text 123 "hello"))
+(check-catch 'type-error
+  (path-append-text (path-join (path-temp-dir) "test.txt") 123)
+) ;check-catch
+(check-catch 'type-error
+  (path-append-text (path-join (path-temp-dir) "test.txt") #\a)
+) ;check-catch
+
 (check-report)

--- a/tests/liii/path/path-copy-test.scm
+++ b/tests/liii/path/path-copy-test.scm
@@ -31,4 +31,10 @@
   (path-unlink dst)
 ) ;let
 
+;; 错误测试
+(check-catch 'type-error (path-copy #\a "x"))
+(check-catch 'type-error (path-copy "x" #\a))
+(check-catch 'type-error (path-copy 123 "x"))
+(check-catch 'type-error (path-copy "x" 123))
+
 (check-report)

--- a/tests/liii/path/path-dir-p-test.scm
+++ b/tests/liii/path/path-dir-p-test.scm
@@ -62,4 +62,8 @@
   (check (path-dir? "Z:/definitely/not/exist") => #f)
 ) ;when
 
+;; 错误测试
+(check-catch 'type-error (path-dir? #\a))
+(check-catch 'type-error (path-dir? 123))
+
 (check-report)

--- a/tests/liii/path/path-file-p-test.scm
+++ b/tests/liii/path/path-file-p-test.scm
@@ -37,4 +37,8 @@
   (check (path-file? "C:/Windows") => #f)
 ) ;when
 
+;; 错误测试
+(check-catch 'type-error (path-file? #\a))
+(check-catch 'type-error (path-file? 123))
+
 (check-report)

--- a/tests/liii/path/path-getsize-test.scm
+++ b/tests/liii/path/path-getsize-test.scm
@@ -52,4 +52,7 @@
   (path-getsize (path "/this/file/does/not/exist"))
 ) ;check-catch
 
+(check-catch 'type-error (path-getsize #\a))
+(check-catch 'type-error (path-getsize 123))
+
 (check-report)

--- a/tests/liii/path/path-read-bytes-test.scm
+++ b/tests/liii/path/path-read-bytes-test.scm
@@ -81,4 +81,7 @@
   (path-read-bytes (path "/this/file/does/not/exist"))
 ) ;check-catch
 
+(check-catch 'type-error (path-read-bytes #\a))
+(check-catch 'type-error (path-read-bytes 123))
+
 (check-report)

--- a/tests/liii/path/path-read-text-test.scm
+++ b/tests/liii/path/path-read-text-test.scm
@@ -79,6 +79,9 @@
   (path-read-text (path "/this/file/does/not/exist"))
 ) ;check-catch
 
+(check-catch 'type-error (path-read-text #\a))
+(check-catch 'type-error (path-read-text 123))
+
 ;; 测试 \r\n 自动转换为 \n
 (let ((crlf-file (path-join (path-temp-dir) "path-read-text-crlf.txt")))
   (when (path-exists? crlf-file)

--- a/tests/liii/path/path-touch-test.scm
+++ b/tests/liii/path/path-touch-test.scm
@@ -75,4 +75,8 @@
   (delete-file (path->string relative-file))
 ) ;let
 
+;; 错误测试
+(check-catch 'type-error (path-touch #\a))
+(check-catch 'type-error (path-touch 123))
+
 (check-report)

--- a/tests/liii/path/path-write-bytes-test.scm
+++ b/tests/liii/path/path-write-bytes-test.scm
@@ -55,5 +55,7 @@
 (check-catch 'type-error
   (path-write-bytes (path-join (path-temp-dir) "x.bin") "not bytes")
 ) ;check-catch
+(check-catch 'type-error (path-write-bytes #\a #u8(1 2 3)))
+(check-catch 'type-error (path-write-bytes 123 #u8(1 2 3)))
 
 (check-report)

--- a/tests/liii/path/path-write-text-test.scm
+++ b/tests/liii/path/path-write-text-test.scm
@@ -75,5 +75,7 @@
 (check-catch 'type-error
   (path-write-text (path-join (path-temp-dir) "test.txt") 123)
 ) ;check-catch
+(check-catch 'type-error (path-write-text #\a "hello"))
+(check-catch 'type-error (path-write-text 123 "hello"))
 
 (check-report)


### PR DESCRIPTION
# [0150] 修复 path 模块传入非字符串/非法参数导致 gf 段错误的问题 (c20 ~ c25)

## 任务相关的代码文件
- src/liii_path.cpp
- goldfish/liii/path.scm
- tests/liii/path/path-dir-p-test.scm
- tests/liii/path/path-file-p-test.scm
- tests/liii/path/path-getsize-test.scm
- tests/liii/path/path-read-text-test.scm
- tests/liii/path/path-read-bytes-test.scm
- tests/liii/path/path-write-text-test.scm
- tests/liii/path/path-write-bytes-test.scm
- tests/liii/path/path-append-text-test.scm
- tests/liii/path/path-touch-test.scm
- tests/liii/path/path-copy-test.scm
- demo/crash/README.md

## 如何测试
```bash
xmake b goldfish
bin/gf tests/liii/path/path-dir-p-test.scm
bin/gf tests/liii/path/path-file-p-test.scm
bin/gf tests/liii/path/path-getsize-test.scm
bin/gf tests/liii/path/path-read-text-test.scm
bin/gf tests/liii/path/path-read-bytes-test.scm
bin/gf tests/liii/path/path-write-text-test.scm
bin/gf tests/liii/path/path-write-bytes-test.scm
bin/gf tests/liii/path/path-append-text-test.scm
bin/gf tests/liii/path/path-touch-test.scm
bin/gf tests/liii/path/path-copy-test.scm
```

预期：全部测试通过，0 failed。

## 2026-09-08 C++ 层为 path 模块胶水函数增加参数类型检查

### What

1. `src/liii_path.cpp` 中的全部 10 个胶水函数（`f_isdir`、`f_isfile`、`f_path_getsize`、`f_path_read_text`、`f_path_read_bytes`、`f_path_write_text`、`f_path_write_bytes`、`f_path_append_text`、`f_path_touch`、`f_path_copy`）入口处增加类型守卫：
   - 字符串参数不是 string 时抛出 `(liii error)` 约定的 `type-error`
   - `f_path_write_bytes` 的 bytevector 参数不是 bytevector 时抛出 `type-error`
2. `goldfish/liii/path.scm` 中为 `path-append-text` 补齐对 `content` 参数的 `(string? content)` 检查。
3. 对应 10 个测试文件中增加参数类型回归测试（均使用公开接口）：
   - `tests/liii/path/path-dir-p-test.scm`（`path-dir?`）
   - `tests/liii/path/path-file-p-test.scm`（`path-file?`）
   - `tests/liii/path/path-getsize-test.scm`（`path-getsize`）
   - `tests/liii/path/path-read-text-test.scm`（`path-read-text`）
   - `tests/liii/path/path-read-bytes-test.scm`（`path-read-bytes`）
   - `tests/liii/path/path-write-text-test.scm`（`path-write-text`）
   - `tests/liii/path/path-write-bytes-test.scm`（`path-write-bytes`）
   - `tests/liii/path/path-append-text-test.scm`（`path-append-text`）
   - `tests/liii/path/path-touch-test.scm`（`path-touch`）
   - `tests/liii/path/path-copy-test.scm`（`path-copy`）
4. 更新 `demo/crash/README.md`，将已修复的 `c20 ~ c25` 移入“历史条目（已修复并移除）”。

### Why

`liii_path.cpp` 中的底层胶水函数直接通过 `s7_string(s7_car(args))` 获取 C 字符串，对非字符串对象（如字符这种标记立即数）强转解引用会导致非法内存访问，触发 SIGSEGV 段错误（exit 139）。

在 C++ 胶水层做好类型防御后，公开包装与根环境直接调用 `g_*` 均得到完整保护，统一抛出符合规范的 `type-error`。

### How

引入 `string_type_error` 辅助函数，在各函数入口通过 `s7_is_string` 和 `s7_is_byte_vector` 检查参数类型。若类型不匹配，通过 `s7_error` 抛出 `(liii error)` 约定的 `type-error`，并在 Scheme 端可通过 `(check-catch 'type-error ...)` 捕获。
