### PR TITLE
[0151] 修复 subprocess 模块非法 env 参数导致 gf 崩溃的问题

### DIFF
--- a/demo/crash/c42-string-cursor-prev-oob.scm
+++ b/demo/crash/c42-string-cursor-prev-oob.scm
@@ -1,0 +1,2 @@
+(import (liii string-cursor))
+(string-cursor-prev "a" -2000000000)

--- a/demo/crash/c43-string-cursor-back-oob.scm
+++ b/demo/crash/c43-string-cursor-back-oob.scm
@@ -1,0 +1,2 @@
+(import (liii string-cursor))
+(string-cursor-back "a" -2000000000 1)

--- a/demo/crash/c44-string-cursor-diff-oob.scm
+++ b/demo/crash/c44-string-cursor-diff-oob.scm
@@ -1,0 +1,2 @@
+(import (liii string-cursor))
+(string-cursor-diff "a" -2 -2000000002)

--- a/devel/0151.md
+++ b/devel/0151.md
@@ -1,0 +1,98 @@
+# [0151] 扫描并修复导致 bin/gf 崩溃的 Scheme 代码实例
+
+## 任务相关的代码文件
+- src/liii_subprocess.cpp
+- goldfish/liii/subprocess.scm
+- tests/liii/subprocess/run-values-test.scm
+- demo/crash/c42-string-cursor-prev-oob.scm
+- demo/crash/c43-string-cursor-back-oob.scm
+- demo/crash/c44-string-cursor-diff-oob.scm
+- devel/0151.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/subprocess/run-values-test.scm
+```
+
+预期：全部测试通过，0 failed。
+
+## 2026-09-08 修复 (liii subprocess) 中的崩溃问题 (c40, c41)
+
+### What
+
+1. `src/liii_subprocess.cpp`：
+   - 增加 `subprocess_type_error` 辅助函数，抛出 `(liii error)` 约定的 `type-error`。
+   - 在 `f_subprocess_run_values` 入口处对 `env` alist 进行严格类型校验：
+     - `env` 参数为非 `#f` 时必须是 proper list；
+     - 每一项必须是 pair；
+     - 每一项的 key 必须是 `string?`；
+     - 每一项的 val 必须是 `string?`；
+     - 类型不符时均抛出 `type-error`。
+   - 修复 `cmd_arg` 为 pair 且元素为空时的潜伏问题，避免调用 `tb_process_init` 传入 `argv[0] == nullptr`。
+2. `goldfish/liii/subprocess.scm`：
+   - 增加 `%valid-env?` 谓词，在 `run-values` 入口处校验 `:env` 参数，非法时抛出 `(type-error "...")`。
+3. `tests/liii/subprocess/run-values-test.scm`：
+   - 增加针对 `:env` 传入字符 key、整数 key、整数 val、非 pair 元素、非 list 类型的回归测试用例。
+4. `demo/crash/`：
+   - 验证通过后移除已修复的 `c40-subprocess-env-char-key.scm` 与 `c41-subprocess-env-integer-key.scm`。
+
+### Why
+
+`f_subprocess_run_values` 遍历 `env_alist` 时直接使用 `s7_string(s7_car(item))`，当传入字符立即数时造成 SIGSEGV 段错误；传入整数时由于 NULL 指针构造 `std::string` 抛出未捕获的 `std::logic_error` 导致 SIGABRT 进程中止。
+同时 Scheme 包装层对 `:env` 缺乏类型前置校验，导致公开接口可直接引发崩溃。
+
+## 2026-09-08 之前的提交和任务描述：发现 subprocess 与 string-cursor 模块的 5 个崩溃实例
+
+### What
+
+在排除 http 模块的前提下，对核心模块的 C++ 胶水实现及公开接口进行了系统性排查，在 `(liii subprocess)` 与 `(liii string-cursor)` 模块中发现了 5 个稳定导致 `bin/gf` 异常终止（段错误 SIGSEGV 或进程中止 SIGABRT）的实例，最小复现用例均已保存至 `demo/crash/`：
+
+| 编号与文件 | 触发代码 | 信号 | 根因分类 |
+|---|---|---|---|
+| `c40-subprocess-env-char-key.scm` | `(run-values "true" :env '((#\a . "1")))` | SIGSEGV (exit 139) | subprocess 胶水层 env 键未检查类型，字符立即数进 `s7_string` 必崩 |
+| `c41-subprocess-env-integer-key.scm` | `(run-values "true" :env '((42 . "1")))` | SIGABRT (exit 134) | subprocess 胶水层 env 键未检查类型，整数进 `s7_string` 返回 NULL，构造 `std::string` 抛出 `std::logic_error` 未捕获 |
+| `c42-string-cursor-prev-oob.scm` | `(string-cursor-prev "a" -2000000000)` | SIGSEGV (exit 139) | string-cursor-prev 游标分支未检查游标偏移上界，`utf8_retreat` 越界读内存 |
+| `c43-string-cursor-back-oob.scm` | `(string-cursor-back "a" -2000000000 1)` | SIGSEGV (exit 139) | string-cursor-back 后退分支未检查游标偏移上界，`utf8_retreat` 越界读内存 |
+| `c44-string-cursor-diff-oob.scm` | `(string-cursor-diff "a" -2 -2000000002)` | SIGSEGV (exit 139) | string-cursor-diff 游标分支未检查上界，`utf8_advance` 在内存中无限前进越界读内存 |
+
+所有 5 个片段均可直接通过公开接口触发，无需直接调用 `g_*` 底层胶水函数。
+
+### Why
+
+#### 1. subprocess 模块缺少 env 键类型检查 (c40, c41)
+在 `src/liii_subprocess.cpp` 的 `f_subprocess_run_values` 中：
+```cpp
+if (s7_is_pair (args) && s7_is_pair (s7_car (args))) {
+  s7_pointer env_alist = s7_car (args);
+  while (s7_is_pair (env_alist)) {
+    s7_pointer item = s7_car (env_alist);
+    if (s7_is_pair (item)) {
+      const char* key = s7_string (s7_car (item)); // <-- 未做 s7_is_string 检查！
+      s7_pointer  val = s7_cdr (item);
+      const char* val_c = s7_is_string (val) ? s7_string (val) : "";
+      env_storage.push_back (string (key) + "=" + val_c);
+    }
+    env_alist = s7_cdr (env_alist);
+  }
+}
+```
+- 对 `val` 做了 `s7_is_string(val) ? s7_string(val) : ""` 的安全保护，但对 `key` 直接调用 `s7_string(s7_car(item))`。
+- 当 `key` 为字符（如 `#\a`）时，由于 s7 字符是标记立即数，`s7_string` 底层将其作为指针强转解引用低地址，触发 SIGSEGV 段错误 (c40)。
+- 当 `key` 为整数（如 `42`）时，`s7_string` 返回 `nullptr`，传给 `std::string(key)` 构造函数时抛出 `std::logic_error: basic_string: construction from null is not valid`。该 C++ 异常未被捕获，直接调用 `std::terminate()` 导致进程 SIGABRT 中止 (c41)。
+- 在 Scheme 包装层 `goldfish/liii/subprocess.scm` 中，未对 `:env` 参数中的 alist 做类型校验，因此公开 API `run`、`run-values` 均可直接触发。
+
+#### 2. string-cursor 模块游标偏移缺少上界检查 (c42, c43, c44)
+游标在 `src/liii_string_cursor.cpp` 中以负整数表示：`cursor = -(byte_offset + 2)`，字节偏移 `byte_offset = -cursor - 2`。
+- `f_string_cursor_prev` (c42)：在 `if (is_cursor)` 分支中仅检查了 `if (off <= 0)`，完全没有检查 `off` 是否超过字符串长度 `len`。当传入超大负整数（如 `-2000000000` 对应偏移 ~2GB）时，`utf8_retreat(s, off)` 向上遍历 UTF-8 续字节 `s[off]`，访问未映射内存页触发 SIGSEGV 段错误。
+- `f_string_cursor_back` / `string_cursor_move` (c43)：在后退分支 `nchars < 0` 中同样仅检查了 `if (off <= 0)`，未检查 `off <= len`，导致 `utf8_retreat` 越界内存访问触发 SIGSEGV 段错误。
+- `f_string_cursor_diff` (c44)：在游标分支中完全未检查 `off1` 与 `off2` 是否越界。当 `off2` 远大于字符串长度时，`while (off1 < off2) { off1 = utf8_advance (s, off1); }` 会从 `s` 一直向前线性扫描内存，最终越界访问触发 SIGSEGV 段错误。
+- 在 Scheme 包装层 `goldfish/liii/string-cursor.scm` 中，`string-cursor-prev`、`string-cursor-back`、`string-cursor-diff` 均直接等同于底层胶水函数，公开 API 均可直接触发。
+
+### How (后续修复建议)
+
+1. **subprocess 模块**：
+   - 在 `f_subprocess_run_values` 解析 `env_alist` 时增加守卫：若 `s7_car(item)` 不是 string，通过 `s7_error` 抛出规范的 `type-error`；或者在 `subprocess.scm` 包装层前置增加对 `env` alist 的类型验证。
+2. **string-cursor 模块**：
+   - 补充校验函数：游标不仅要求 `offset >= 0`，还必须满足 `offset <= len`（`end` 游标对应 `offset == len`）。
+   - 在 `f_string_cursor_prev`、`string_cursor_move`、`f_string_cursor_diff` 中，进入前进/后退循环前先校验游标偏移合法性，越界时抛出 `value-error`（"cursor out of range"）。

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -237,6 +237,14 @@
       ) ;or
     ) ;define
 
+    (define (%valid-env? env)
+      (or (not env)
+        (and (list? env)
+          (every (lambda (x) (and (pair? x) (string? (car x)) (string? (cdr x)))) env)
+        ) ;and
+      ) ;or
+    ) ;define
+
     (define (run-values command . opts)
       (let ((cwd (%keyword-value :cwd opts #f))
             (env (%keyword-value :env opts #f))
@@ -267,6 +275,9 @@
                          stderr
                        ) ;format
           ) ;value-error
+        ) ;unless
+        (unless (%valid-env? env)
+          (type-error "run-values: :env must be a list of (key . value) string pairs")
         ) ;unless
         (when cwd
           (set! orig-dir (getcwd))

--- a/src/liii_subprocess.cpp
+++ b/src/liii_subprocess.cpp
@@ -36,6 +36,11 @@ using std::vector;
 
 enum class redirect_mode { tee, capture, inherit, discard, file };
 
+inline s7_pointer
+subprocess_type_error (s7_scheme* sc, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, "type-error"), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
 s7_pointer
 f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
   s7_pointer cmd_arg= s7_car (args);
@@ -52,17 +57,30 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
 
   vector<string>      env_storage;
   vector<const char*> envp;
-  if (s7_is_pair (args) && s7_is_pair (s7_car (args))) {
-    s7_pointer env_alist= s7_car (args);
+  if (s7_is_pair (args) && !s7_is_null (sc, s7_car (args)) && s7_car (args) != s7_f (sc)) {
+    s7_pointer env_arg= s7_car (args);
+    if (!s7_is_pair (env_arg)) {
+      return subprocess_type_error (sc, "g_subprocess-run-values: env must be an alist", env_arg);
+    }
+    s7_pointer env_alist= env_arg;
     while (s7_is_pair (env_alist)) {
       s7_pointer item= s7_car (env_alist);
-      if (s7_is_pair (item)) {
-        const char* key  = s7_string (s7_car (item));
-        s7_pointer  val  = s7_cdr (item);
-        const char* val_c= s7_is_string (val) ? s7_string (val) : "";
-        env_storage.push_back (string (key) + "=" + val_c);
+      if (!s7_is_pair (item)) {
+        return subprocess_type_error (sc, "g_subprocess-run-values: env element must be a pair", item);
       }
+      s7_pointer key_arg= s7_car (item);
+      if (!s7_is_string (key_arg)) {
+        return subprocess_type_error (sc, "g_subprocess-run-values: env key must be a string", key_arg);
+      }
+      s7_pointer val_arg= s7_cdr (item);
+      if (!s7_is_string (val_arg)) {
+        return subprocess_type_error (sc, "g_subprocess-run-values: env value must be a string", val_arg);
+      }
+      env_storage.push_back (string (s7_string (key_arg)) + "=" + s7_string (val_arg));
       env_alist= s7_cdr (env_alist);
+    }
+    if (!s7_is_null (sc, env_alist)) {
+      return subprocess_type_error (sc, "g_subprocess-run-values: env must be a proper list", env_arg);
     }
     for (auto& s : env_storage) {
       envp.push_back (s.c_str ());
@@ -333,8 +351,8 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
       }
       p= s7_cdr (p);
     }
-    argv.push_back (nullptr);
     if (!argv.empty ()) {
+      argv.push_back (nullptr);
       process= tb_process_init (argv[0], argv.data (), &attr);
     }
   }

--- a/tests/liii/subprocess/run-values-test.scm
+++ b/tests/liii/subprocess/run-values-test.scm
@@ -251,4 +251,11 @@
   ) ;let-values
 ) ;when
 
+;; :env 参数类型检查回归测试
+(check-catch 'type-error (run-values "true" :env '((#\a . "1"))))
+(check-catch 'type-error (run-values "true" :env '((42 . "1"))))
+(check-catch 'type-error (run-values "true" :env '(("FOO" . 42))))
+(check-catch 'type-error (run-values "true" :env '(42)))
+(check-catch 'type-error (run-values "true" :env 42))
+
 (check-report)


### PR DESCRIPTION
## 任务相关的代码文件
- src/liii_subprocess.cpp
- goldfish/liii/subprocess.scm
- tests/liii/subprocess/run-values-test.scm
- demo/crash/c42-string-cursor-prev-oob.scm
- demo/crash/c43-string-cursor-back-oob.scm
- demo/crash/c44-string-cursor-diff-oob.scm
- devel/0151.md

## What
1. `src/liii_subprocess.cpp`：
   - 增加 `subprocess_type_error` 辅助函数，统一抛出 `(liii error)` 约定的 `type-error`。
   - 在 `f_subprocess_run_values` 解析 `env` 参数时增加完整类型守卫：要求为 proper alist，且每一项的 key 与 val 均必须为 `string?`，否则抛出 `type-error`。
   - 修复命令列表为空时传入 `argv[0] == nullptr` 的潜在空指针调用隐患。
2. `goldfish/liii/subprocess.scm`：
   - 增加 `%valid-env?` 谓词，在公开入口 `run-values` 中对 `:env` 参数进行前置类型检查，非法时调用 `(type-error ...)`。
3. `tests/liii/subprocess/run-values-test.scm`：
   - 增加针对 `:env` 传入字符 key、整数 key、整数 val、非 pair 元素、非 list 类型的回归测试用例。
4. `demo/crash/`：
   - 修复并验证通过后移除已解决的 `c40-subprocess-env-char-key.scm` 与 `c41-subprocess-env-integer-key.scm`。
   - 保留 `c42 ~ c44` 作为后续 `string-cursor` 模块修复的复现用例。

## Why
`f_subprocess_run_values` 遍历 `env_alist` 时直接使用 `s7_string(s7_car(item))`，当传入字符立即数时造成 SIGSEGV 段错误；传入整数时由于 NULL 指针构造 `std::string` 抛出未捕获的 `std::logic_error` 导致 SIGABRT 进程中止。
同时 Scheme 包装层对 `:env` 缺乏类型前置校验，导致公开接口可直接引发崩溃。

## 如何测试
```bash
xmake b goldfish
bin/gf tests/liii/subprocess/run-values-test.scm
```
预期：全部测试通过，0 failed。