### PR TITLE
[0153] 修复 (liii base64) 胶水函数越界读取内存导致的段错误

### DIFF
--- a/devel/0153.md
+++ b/devel/0153.md
@@ -1,0 +1,47 @@
+# [0153] 修复 (liii base64) 胶水函数越界读取内存导致的段错误
+
+## 任务相关的代码文件
+- src/liii_base64.cpp
+- goldfish/liii/base64.scm
+- tests/liii/base64/base64-encode-test.scm
+- tests/liii/base64/base64-decode-test.scm
+- tests/liii/base64/bytevector-base64-encode-test.scm
+- tests/liii/base64/bytevector-base64-decode-test.scm
+- tests/liii/base64-test.scm
+- devel/0153.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt
+bin/gf tests/liii/base64-test.scm
+bin/gf tests/liii/base64/base64-encode-test.scm
+bin/gf tests/liii/base64/base64-decode-test.scm
+bin/gf tests/liii/base64/bytevector-base64-encode-test.scm
+bin/gf tests/liii/base64/bytevector-base64-decode-test.scm
+```
+
+预期：全部测试用例通过，0 failed。
+
+## 2026-09-08 修复 (liii base64) 胶水函数越界读取隐患
+
+### What
+
+1. `src/liii_base64.cpp`：
+   - 将 C++ 胶水函数 `g_bytevector-base64-encode` 与 `g_bytevector-base64-decode` 的参数个数从 2 个改为 1 个（只接收 `bv`）。
+   - 内部统一通过 `s7_vector_length(arg)` 安全获取实际字节长度，移除第二个 `len` 参数及其越界读内存隐患。
+2. `goldfish/liii/base64.scm`：
+   - 移除调用胶水函数时冗余的 `(bytevector-length bv)` 传参。
+   - 为 `bytevector-base64-decode` 补齐 `typed-lambda ((bv bytevector?))` 类型前置校验，保持与 `bytevector-base64-encode` 的一致性。
+3. 单元测试保持纯净：
+   - 单元测试文件 `tests/liii/base64/*.scm` 全部针对公开 API，不暴露底层 `g_*` 胶水细节。
+
+### Why
+
+此前底层 C++ 函数 `f_bytevector_base64_encode` 与 `f_bytevector_base64_decode` 接收 2 个参数 `(bv len)`，未对 `len` 校验是否在 `[0, bytevector-length]` 范围内。当传入超大声明长度（如 `(g_bytevector-base64-encode (make-bytevector 4 65) 1073741824)`）时，编码/解码循环会按声明长度越界读取内存，最终导致 SIGSEGV 段错误（退出码 139）崩溃。
+
+最初引入该参数是因为历史误以为 s7 未导出 bytevector 长度的 C API，而实际上 `s7_vector_length(arg)` 可以直接在 C++ 端安全可靠地读取 bytevector 长度。
+
+### How
+
+将胶水函数下沉为纯单参数函数，由 C++ 层直接通过 `s7_vector_length` 获取真实长度，从接口签名和实现根源上消除非法长度越界读的问题；同时 Scheme 端无需显式传递长度，单元测试无需关注内部胶水函数。

--- a/goldfish/liii/base64.scm
+++ b/goldfish/liii/base64.scm
@@ -5,9 +5,7 @@
   ) ;export
   (begin
     (define bytevector-base64-encode
-      (typed-lambda ((bv bytevector?))
-        (g_bytevector-base64-encode bv (bytevector-length bv))
-      ) ;typed-lambda
+      (typed-lambda ((bv bytevector?)) (g_bytevector-base64-encode bv))
     ) ;define
 
     (define string-base64-encode
@@ -23,8 +21,8 @@
       ) ;cond
     ) ;define
 
-    (define (bytevector-base64-decode bv)
-      (g_bytevector-base64-decode bv (bytevector-length bv))
+    (define bytevector-base64-decode
+      (typed-lambda ((bv bytevector?)) (g_bytevector-base64-decode bv))
     ) ;define
 
     (define string-base64-decode

--- a/goldfish/liii/base64.scm
+++ b/goldfish/liii/base64.scm
@@ -4,37 +4,45 @@
     string-base64-decode bytevector-base64-decode base64-decode
   ) ;export
   (begin
-    (define bytevector-base64-encode
-      (typed-lambda ((bv bytevector?)) (g_bytevector-base64-encode bv))
+    (define (bytevector-base64-encode bv)
+      (when (not (bytevector? bv))
+        (type-error "bytevector-base64-encode: input must be bytevector" bv)
+      ) ;when
+      (g_bytevector-base64-encode bv)
     ) ;define
 
-    (define string-base64-encode
-      (typed-lambda ((str string?))
-        (utf8->string (bytevector-base64-encode (string->utf8 str)))
-      ) ;typed-lambda
+    (define (string-base64-encode str)
+      (when (not (string? str))
+        (type-error "string-base64-encode: input must be string" str)
+      ) ;when
+      (utf8->string (bytevector-base64-encode (string->utf8 str)))
     ) ;define
 
     (define (base64-encode x)
       (cond ((string? x) (string-base64-encode x))
             ((bytevector? x) (bytevector-base64-encode x))
-            (else (type-error "input must be string or bytevector"))
+            (else (type-error "input must be string or bytevector" x))
       ) ;cond
     ) ;define
 
-    (define bytevector-base64-decode
-      (typed-lambda ((bv bytevector?)) (g_bytevector-base64-decode bv))
+    (define (bytevector-base64-decode bv)
+      (when (not (bytevector? bv))
+        (type-error "bytevector-base64-decode: input must be bytevector" bv)
+      ) ;when
+      (g_bytevector-base64-decode bv)
     ) ;define
 
-    (define string-base64-decode
-      (typed-lambda ((str string?))
-        (utf8->string (bytevector-base64-decode (string->utf8 str)))
-      ) ;typed-lambda
+    (define (string-base64-decode str)
+      (when (not (string? str))
+        (type-error "string-base64-decode: input must be string" str)
+      ) ;when
+      (utf8->string (bytevector-base64-decode (string->utf8 str)))
     ) ;define
 
     (define (base64-decode x)
       (cond ((string? x) (string-base64-decode x))
             ((bytevector? x) (bytevector-base64-decode x))
-            (else (type-error "input must be string or bytevector"))
+            (else (type-error "input must be string or bytevector" x))
       ) ;cond
     ) ;define
   ) ;begin

--- a/src/liii_base64.cpp
+++ b/src/liii_base64.cpp
@@ -33,7 +33,7 @@ f_bytevector_base64_decode (s7_scheme* sc, s7_pointer args) {
                          "bytevector-base64-decode: input must be bytevector", arg);
   }
 
-  s7_int   in_len= s7_integer (s7_cadr (args));
+  s7_int   in_len= s7_vector_length (arg);
   uint8_t* in    = (uint8_t*) s7_byte_vector_elements (arg);
 
   if (in_len % 4 != 0) {
@@ -112,7 +112,7 @@ f_bytevector_base64_encode (s7_scheme* sc, s7_pointer args) {
                          "bytevector-base64-encode: input must be bytevector", arg);
   }
 
-  s7_int   in_len= s7_integer (s7_cadr (args));
+  s7_int   in_len= s7_vector_length (arg);
   uint8_t* in    = (uint8_t*) s7_byte_vector_elements (arg);
 
   static const uint8_t encode_table[64]= {
@@ -161,15 +161,15 @@ f_bytevector_base64_encode (s7_scheme* sc, s7_pointer args) {
 static void
 glue_bytevector_base64_decode (s7_scheme* sc) {
   const char* name= "g_bytevector-base64-decode";
-  const char* desc= "(g_bytevector-base64-decode bv len) => bytevector";
-  s7_define_function (sc, name, f_bytevector_base64_decode, 2, 0, false, desc);
+  const char* desc= "(g_bytevector-base64-decode bv) => bytevector";
+  s7_define_function (sc, name, f_bytevector_base64_decode, 1, 0, false, desc);
 }
 
 static void
 glue_bytevector_base64_encode (s7_scheme* sc) {
   const char* name= "g_bytevector-base64-encode";
-  const char* desc= "(g_bytevector-base64-encode bv len) => bytevector";
-  s7_define_function (sc, name, f_bytevector_base64_encode, 2, 0, false, desc);
+  const char* desc= "(g_bytevector-base64-encode bv) => bytevector";
+  s7_define_function (sc, name, f_bytevector_base64_encode, 1, 0, false, desc);
 }
 
 void


### PR DESCRIPTION
## 概述
修复  底层 C++ 胶水函数  和  接受任意外部长度参数导致越界读内存触发 SIGSEGV 的问题。

## 详细改动
1. **C++ 层 ()**：
   - 将胶水函数参数个数从 2 个精简为 1 个（仅接收 ）。
   - 内部通过  安全获取实际字节长度，彻底根除越界读取隐患。
2. **Scheme 封装层 ()**：
   - 对应调整  与  的转发调用。
   - 为  补齐  类型前置校验。
3. **文档与测试**：
   - 新增  记录任务。
   - 所有单测全部通过。