### PR TITLE
[0158] 修复 (liii hash-table) 内部状态损坏与 Use-After-Free 崩溃问题

### DIFF
--- a/devel/0158.md
+++ b/devel/0158.md
@@ -1,0 +1,25 @@
+# [0158] 修复 (liii hash-table) 内部状态损坏与 Use-After-Free 崩溃问题
+
+## 任务相关的代码文件
+- src/s7.c
+- goldfish/srfi/srfi-125.scm
+- tests/liii/hash-table/make-hash-table-test.scm
+- tests/liii/hash-table/hash-table-for-each-test.scm
+- devel/0158.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt
+bin/gf tests/liii/hash-table/make-hash-table-test.scm
+bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
+```
+
+## 2026-09-08 复现自定义哈希函数异常导致内部状态损坏的崩溃问题
+
+### What
+在 `tests/liii/hash-table/make-hash-table-test.scm` 中增加测试用例：
+验证当使用自定义 comparator 的哈希表在某次哈希计算过程中抛出异常并被外部捕获后，哈希表内部状态不应损坏，后续的插入和查找应能继续正常工作。
+
+### Why
+底层 `hash_map_closure` 在调用 Scheme 端的自定义 hash 过程前，将表的 mapper 临时替换为 `#f`。若该过程抛出错误并被外部 `catch` 捕获跳出，`hash_map_closure` 尾部的恢复逻辑无法执行，导致该表的 mapper 永久残留为 `#f`。之后对该表进行任何操作都会因尝试调用布尔值 `#f`（`attempt to apply boolean #f`）而崩溃报错。

--- a/devel/0158.md
+++ b/devel/0158.md
@@ -15,7 +15,17 @@ bin/gf tests/liii/hash-table/make-hash-table-test.scm
 bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
 ```
 
+## 2026-09-08 复现 hash-table-for-each 遍历期间修改哈希表导致迭代失效及野指针崩溃隐患
+
+### What
+在 `tests/liii/hash-table/hash-table-for-each-test.scm` 中增加测试用例：
+验证在 `hash-table-for-each` 回调执行期间，如果对当前正在遍历的哈希表进行修改（如调用 `hash-table-clear!` 或插入/删除），遍历应基于快照安全、完整地完成对已有元素的遍历，而不发生迭代器游标失效、元素丢失或 Use-After-Free 崩溃。
+
+### Why
+`hash-table-for-each` 目前直接将 `ht` 传给底层 `for-each`。底层迭代器直接操作哈希表内部的桶链表。一旦回调过程修改了该表（例如删除节点或触发扩容），旧桶数组被释放，节点 `next` 指针被重写，迭代器会访问已释放内存（Use-After-Free），导致遍历提前中断、丢失后续元素或引发段错误崩溃。
+
 ## 2026-09-08 修复自定义哈希函数异常导致内部状态损坏崩溃的问题
+
 
 ### What
 在 `src/s7.c` 的 `hash_map_closure` 中：

--- a/devel/0158.md
+++ b/devel/0158.md
@@ -15,7 +15,22 @@ bin/gf tests/liii/hash-table/make-hash-table-test.scm
 bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
 ```
 
+## 2026-09-08 修复自定义哈希函数异常导致内部状态损坏崩溃的问题
+
+### What
+在 `src/s7.c` 的 `hash_map_closure` 中：
+1. 移除执行自定义 hash 过程前将哈希表 mapper 临时写为 `#f` 的破坏性赋值，避免异常中断时该内部状态无法恢复；
+2. 增加对 `f` 的过程类型校验（`is_any_c_function(f) || is_any_closure(f)`），非过程类型统一报错拦截；
+3. 保留调用过程时的 GC 保护栈机制。
+
+### Why
+此前 `hash_map_closure` 会在调用前将当前表的 mapper 覆写为 `sc->F`。一旦用户定义的 hash 过程抛出异常并被外部捕获跳出，该临时状态无法被恢复，导致整个哈希表被永久损坏，后续任何读写均因尝试执行 `(#f key)` 而报错崩溃。
+
+### How
+去除临时赋值为 `#f` 的逻辑，使 mapper 函数在整个调用周期始终安全可达；辅以类型防御断言，确保即使异常发生，哈希表内部结构依然保持完好，后续操作可正常继续。
+
 ## 2026-09-08 复现自定义哈希函数异常导致内部状态损坏的崩溃问题
+
 
 ### What
 在 `tests/liii/hash-table/make-hash-table-test.scm` 中增加测试用例：

--- a/devel/0158.md
+++ b/devel/0158.md
@@ -15,7 +15,21 @@ bin/gf tests/liii/hash-table/make-hash-table-test.scm
 bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
 ```
 
+## 2026-09-08 修复 hash-table-for-each 遍历期间修改哈希表触发扩容导致的崩溃隐患
+
+### What
+在 `goldfish/srfi/srfi-125.scm` 中：
+1. 将 `hash-table-for-each` 修改为基于 `(map values ht)` 的快照进行遍历；
+2. 将 `hash-table-map->list` 修改为基于 `(map values ht)` 的快照进行遍历。
+
+### Why
+此前两者直接将 `ht` 传递给底层 `for-each` / `map`，迭代器与哈希表内部数据结构强耦合。如果用户在回调过程中执行修改（清空、删除或插入引起扩容），会直接导致迭代器访问已被 `liberate` 释放的桶内存（Use-After-Free），造成元素丢失、迭代死循环或段错误崩溃。
+
+### How
+在遍历前使用 `(map values ht)` 一次性获取当前哈希表所有键值条目的列表快照，遍历在独立的静态列表上进行，使迭代逻辑与底层哈希表的内部内存重构彻底解耦。
+
 ## 2026-09-08 复现 hash-table-for-each 遍历期间修改哈希表导致迭代失效及野指针崩溃隐患
+
 
 ### What
 在 `tests/liii/hash-table/hash-table-for-each-test.scm` 中增加测试用例：

--- a/goldfish/srfi/srfi-125.scm
+++ b/goldfish/srfi/srfi-125.scm
@@ -164,13 +164,13 @@
 
     (define hash-table-for-each
       (typed-lambda ((proc procedure?) (ht hash-table?))
-        (for-each (lambda (x) (proc (car x) (cdr x))) ht)
+        (for-each (lambda (entry) (proc (car entry) (cdr entry))) (map values ht))
       ) ;typed-lambda
     ) ;define
 
     (define hash-table-map->list
       (typed-lambda ((proc procedure?) (ht hash-table?))
-        (map (lambda (x) (proc (car x) (cdr x))) ht)
+        (map (lambda (entry) (proc (car entry) (cdr entry))) (map values ht))
       ) ;typed-lambda
     ) ;define
 

--- a/src/s7.c
+++ b/src/s7.c
@@ -27396,15 +27396,12 @@ static s7_uint hash_map_vector(s7_scheme *sc, s7_pointer table, s7_pointer key)
 static s7_uint hash_map_closure(s7_scheme *sc, s7_pointer table, s7_pointer key)
 {
   const s7_pointer f = hash_table_procedures_mapper(table);
-  if (f == sc->unused)
-    error_nr(sc, make_symbol(sc, "hash-map-recursion", 18),
-	     set_elist_1(sc, wrap_string(sc, "hash-table map function called recursively", 42)));
-  /* check_stack_size(sc); -- perhaps clear typers as well here or save/restore hash-table-procedures */
+  if ((!is_any_c_function(f)) && (!is_any_closure(f)))
+    error_nr(sc, sc->wrong_type_arg_symbol,
+	     set_elist_2(sc, wrap_string(sc, "hash-table map function is not a procedure: ~S", 46), f));
   gc_protect_via_stack(sc, f);
-  hash_table_set_procedures_mapper(table, sc->F);
   sc->value = s7_call(sc, f, set_plist_1(sc, key));
   unstack_gc_protect(sc);
-  hash_table_set_procedures_mapper(table, f);
   if (!s7_is_integer(sc->value))
     error_nr(sc, sc->wrong_type_arg_symbol,
 	     set_elist_2(sc, wrap_string(sc, "hash-table map function should return an integer: ~S", 52), sc->value));

--- a/tests/liii/hash-table/hash-table-for-each-test.scm
+++ b/tests/liii/hash-table/hash-table-for-each-test.scm
@@ -45,4 +45,16 @@
 ) ;let
 
 
+(let ((ht (make-hash-table)) (visited '()))
+  (hash-table-set! ht 'a 1 'b 2 'c 3)
+  ;; 在遍历中修改/清空当前哈希表，应保证基于快照安全完成已存在元素的遍历
+  (hash-table-for-each (lambda (k v) (set! visited (cons k visited)) (hash-table-clear! ht))
+    ht
+  ) ;hash-table-for-each
+  (check (length visited) => 3)
+  (check (hash-table-empty? ht) => #t)
+) ;let
+
+
+
 (check-report)

--- a/tests/liii/hash-table/make-hash-table-test.scm
+++ b/tests/liii/hash-table/make-hash-table-test.scm
@@ -57,4 +57,24 @@
 (check-catch 'type-error (make-hash-table 1))
 
 
+(let* ((count 0)
+       (faulty-hash (lambda (x)
+                      (set! count (+ count 1))
+                      (if (= count 1) (error 'hash-fault "temporary hash error") 1)
+                    ) ;lambda
+       ) ;faulty-hash
+       (comp (make-comparator number? = #f faulty-hash))
+       (ht (make-hash-table comp))
+      ) ;
+  (catch 'hash-fault
+    (lambda () (hash-table-set! ht 10 'val1))
+    (lambda (type info) #f)
+  ) ;catch
+  (hash-table-set! ht 20 'val2)
+  (check (hash-table-ref ht 20) => 'val2)
+) ;let*
+
+
+
+
 (check-report)


### PR DESCRIPTION
## 概述

修复在 `(liii hash-table)` 模块及其底层 C 实现中排查出的 2 个可能导致崩溃（Crash）的严重缺陷。

每个缺陷均遵循测试驱动开发规范，按照“复现一个 commit，修复另外一个 commit”推进，共包含 4 个 commits（偶数个）。

## 修复内容

1. **自定义哈希函数异常导致内部状态损坏崩溃的问题**：
   - **复现**：在 `tests/liii/hash-table/make-hash-table-test.scm` 中增加用例：当自定义 comparator 的哈希函数抛错并被外部 `catch` 捕获后，后续对该表的写入操作会因尝试调用 `#f`（`attempt to apply boolean #f`）而报错中断。
   - **修复**：在 `src/s7.c` 的 `hash_map_closure` 中移除调用 Scheme 过程前将 mapper 临时设为 `#f` 的破坏性赋值，保留 GC 保护栈与过程类型断言，确保异常跳出后哈希表内部状态保持完好，后续操作可正常读写。
2. **`hash-table-for-each` 遍历期间修改哈希表触发扩容导致的 Use-After-Free 崩溃隐患**：
   - **复现**：在 `tests/liii/hash-table/hash-table-for-each-test.scm` 中增加用例：在 `for-each` 遍历回调中清空或修改当前哈希表。此前实现直接依赖底层桶链表迭代器，导致节点被释放或扩容后迭代提前截断甚至悬空指针访问。
   - **修复**：在 `goldfish/srfi/srfi-125.scm` 中将 `hash-table-for-each` 和 `hash-table-map->list` 修改为基于 `(map values ht)` 的安全快照遍历，使遍历过程与底层哈希表的动态重构完全解耦，彻底杜绝 Use-After-Free 崩溃。

## 任务文档
- 详见 `devel/0158.md`