### PR TITLE
[0158] 修复 hash-table-ref/default 过程误调用及补全类型检查 (Part 2)

### DIFF
--- a/devel/0158.md
+++ b/devel/0158.md
@@ -19,6 +19,15 @@ bin/gf tests/liii/hash-table/make-hash-table-test.scm
 bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
 ```
 
+## 2026-09-08 为 hash-table-keys/values/clear! 增加类型检查复现用例
+
+### What
+在 `tests/liii/hash-table/hash-table-keys-test.scm`、`hash-table-values-test.scm`、`hash-table-clear-bang-test.scm` 中增加测试用例：
+验证当向这些函数传入非哈希表对象（如普通 alist 或非序列类型）时，应统一在入口被拦截并抛出规范的 `type-error`。
+
+### Why
+`hash-table-keys`、`hash-table-values`、`hash-table-clear!`、`hash-table-find` 等函数此前缺少参数类型校验，若传入 alist 列表会被错误地当成哈希表提取键值，若传入非序列对象则穿透到底层引发未捕获的运行时异常。
+
 ## 2026-09-08 修复 hash-table-ref/default 对有参过程默认值误调用的问题
 
 ### What

--- a/devel/0158.md
+++ b/devel/0158.md
@@ -19,6 +19,23 @@ bin/gf tests/liii/hash-table/make-hash-table-test.scm
 bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
 ```
 
+## 2026-09-08 为 hash-table-keys/values/clear! 等补充类型前置断言
+
+### What
+在 `goldfish/srfi/srfi-125.scm` 中，为以下函数增加 `assert-hash-table-type` 类型断言：
+1. `hash-table-keys`
+2. `hash-table-values`
+3. `hash-table-clear!`
+4. `hash-table-find`
+5. `hash-table-contains?`
+6. `hash-table-empty?`
+
+### Why
+此前这些函数未进行类型断言，当传入非哈希表参数时，容易将普通 alist 列表误当做哈希表进行操作，或将非序列类型穿透传递至底层引发未捕获的运行时异常。
+
+### How
+在函数入口处统一调用 `(assert-hash-table-type ht <func-symbol>)`，非哈希表对象统一抛出标准的 `type-error`。
+
 ## 2026-09-08 为 hash-table-keys/values/clear! 增加类型检查复现用例
 
 ### What

--- a/devel/0158.md
+++ b/devel/0158.md
@@ -19,6 +19,15 @@ bin/gf tests/liii/hash-table/make-hash-table-test.scm
 bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
 ```
 
+## 2026-09-08 修复 hash-table-ref/default 对有参过程默认值误调用的问题
+
+### What
+在 `goldfish/srfi/srfi-125.scm` 的 `hash-table-ref/default` 中，增加 `(aritable? default 0)` 判断：
+仅当 `default` 是可接收 0 个参数的过程（thunk）时才调用执行；若为接收参数的过程（或其他普通值），则直接作为默认值返回。
+
+### Why
+避免在默认值为有参过程时因无参强行调用而抛出 `wrong-number-of-args` 崩溃报错，连带保障 `hash-table-update!/default` 在此类场景下的安全性。
+
 ## 2026-09-08 复现 hash-table-ref/default 对有参过程默认值误执行导致崩溃报错
 
 ### What

--- a/devel/0158.md
+++ b/devel/0158.md
@@ -5,6 +5,10 @@
 - goldfish/srfi/srfi-125.scm
 - tests/liii/hash-table/make-hash-table-test.scm
 - tests/liii/hash-table/hash-table-for-each-test.scm
+- tests/liii/hash-table/hash-table-ref-slash-default-test.scm
+- tests/liii/hash-table/hash-table-keys-test.scm
+- tests/liii/hash-table/hash-table-values-test.scm
+- tests/liii/hash-table/hash-table-clear-bang-test.scm
 - devel/0158.md
 
 ## 如何测试
@@ -14,6 +18,15 @@ bin/gf fmt
 bin/gf tests/liii/hash-table/make-hash-table-test.scm
 bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
 ```
+
+## 2026-09-08 复现 hash-table-ref/default 对有参过程默认值误执行导致崩溃报错
+
+### What
+在 `tests/liii/hash-table/hash-table-ref-slash-default-test.scm` 中增加测试用例：
+验证当 `default` 参数传入一个有参过程（如 `(lambda (x) (+ x 1))`）时，未命中的情况下应直接返回该过程作为默认值，而不应被强行无参执行。
+
+### Why
+此前 `hash-table-ref/default` 使用 `(if (procedure? default) (default) default)`。一旦用户传入需要参数的过程作为默认值，会被当作 0 参过程调用，引发 `wrong-number-of-args` 错误崩溃中断。
 
 ## 2026-09-08 修复 hash-table-for-each 遍历期间修改哈希表触发扩容导致的崩溃隐患
 

--- a/goldfish/srfi/srfi-125.scm
+++ b/goldfish/srfi/srfi-125.scm
@@ -66,10 +66,12 @@
     ) ;define
 
     (define (hash-table-contains? ht key)
+      (assert-hash-table-type ht hash-table-contains?)
       (not (not (hash-table-ref ht key)))
     ) ;define
 
     (define (hash-table-empty? ht)
+      (assert-hash-table-type ht hash-table-empty?)
       (zero? (hash-table-size ht))
     ) ;define
 
@@ -117,14 +119,17 @@
     ) ;define
 
     (define (hash-table-clear! ht)
+      (assert-hash-table-type ht hash-table-clear!)
       (for-each (lambda (key) (hash-table-set! ht key #f)) (hash-table-keys ht))
     ) ;define
 
     (define (hash-table-keys ht)
+      (assert-hash-table-type ht hash-table-keys)
       (map car ht)
     ) ;define
 
     (define (hash-table-values ht)
+      (assert-hash-table-type ht hash-table-values)
       (map cdr ht)
     ) ;define
 
@@ -137,6 +142,7 @@
     ) ;define
 
     (define (hash-table-find proc ht failure)
+      (assert-hash-table-type ht hash-table-find)
       (let ((keys (hash-table-keys ht)))
         (let loop
           ((keys keys))

--- a/goldfish/srfi/srfi-125.scm
+++ b/goldfish/srfi/srfi-125.scm
@@ -78,7 +78,9 @@
     ) ;define
 
     (define (hash-table-ref/default ht key default)
-      (or (hash-table-ref ht key) (if (procedure? default) (default) default))
+      (or (hash-table-ref ht key)
+        (if (and (procedure? default) (aritable? default 0)) (default) default)
+      ) ;or
     ) ;define
 
     (define (hash-table-set! ht . rest)

--- a/tests/liii/hash-table/hash-table-clear-bang-test.scm
+++ b/tests/liii/hash-table/hash-table-clear-bang-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii hash-table))
+(import (liii check) (liii error) (liii hash-table))
 
 
 (check-set-mode! 'report-failed)
@@ -41,6 +41,10 @@
   (check (hash-table-ref ht 'key) => #f)
   (check (hash-table-ref ht 'key1) => #f)
 ) ;let
+
+
+(check-catch 'type-error (hash-table-clear! "not-a-table"))
+
 
 
 (check-report)

--- a/tests/liii/hash-table/hash-table-keys-test.scm
+++ b/tests/liii/hash-table/hash-table-keys-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii hash-table))
+(import (liii check) (liii error) (liii hash-table))
 
 
 (check-set-mode! 'report-failed)
@@ -41,6 +41,11 @@
   (hash-table-set! ht 'k1 'v1)
   (check (hash-table-keys ht) => '(k1))
 ) ;let
+
+
+(check-catch 'type-error (hash-table-keys '((k1 . v1))))
+(check-catch 'type-error (hash-table-keys 123))
+
 
 
 (check-report)

--- a/tests/liii/hash-table/hash-table-ref-slash-default-test.scm
+++ b/tests/liii/hash-table/hash-table-ref-slash-default-test.scm
@@ -48,4 +48,10 @@
 ) ;let
 
 
+(let ((ht (make-hash-table)) (fn (lambda (x) (+ x 1))))
+  (check ((hash-table-ref/default ht 'not-exist fn) 5) => 6)
+) ;let
+
+
+
 (check-report)

--- a/tests/liii/hash-table/hash-table-values-test.scm
+++ b/tests/liii/hash-table/hash-table-values-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii hash-table))
+(import (liii check) (liii error) (liii hash-table))
 
 
 (check-set-mode! 'report-failed)
@@ -41,6 +41,11 @@
   (hash-table-set! ht 'k1 'v1)
   (check (hash-table-values ht) => '(v1))
 ) ;let
+
+
+(check-catch 'type-error (hash-table-values '((k1 . v1))))
+(check-catch 'type-error (hash-table-values 123))
+
 
 
 (check-report)


### PR DESCRIPTION
## 概述

本 PR 是 [0158] 任务的第二部分（Part 2），继续修复在 `(liii hash-table)` 模块中排查出的两处崩溃与异常隐患。

共包含 4 个 commits（偶数个），每个问题严格按照“复现一个 commit，修复另外一个 commit”推进。

## 修复内容

1. **`hash-table-ref/default` 对有参过程默认值误调用的崩溃问题**：
   - **复现**：在 `tests/liii/hash-table/hash-table-ref-slash-default-test.scm` 中增加用例：当 `default` 参数传入需要参数的过程（如 `(lambda (x) (+ x 1))`）时，未命中时原实现会无参强行调用该过程导致 `wrong-number-of-args` 崩溃报错。
   - **修复**：在 `goldfish/srfi/srfi-125.scm` 的 `hash-table-ref/default` 中增加 `(aritable? default 0)` 判断，仅当为 0 参过程（thunk）时才调用执行，有参过程则安全返回其本身，连带保障 `hash-table-update!/default` 的安全性。
2. **`hash-table-keys/values/clear!` 等缺少类型断言导致的异常隐患**：
   - **复现**：在 `hash-table-keys-test.scm`、`hash-table-values-test.scm`、`hash-table-clear-bang-test.scm` 中增加用例：传入非哈希表类型（如普通 alist 列表或非序列对象）应被入口拦截并抛出 `type-error`。原实现此前会将 alist 误当做哈希表操作，非序列对象则穿透到底层引发未处理异常。
   - **修复**：在 `goldfish/srfi/srfi-125.scm` 中为 `hash-table-keys`、`hash-table-values`、`hash-table-clear!`、`hash-table-find`、`hash-table-contains?`、`hash-table-empty?` 增加 `assert-hash-table-type` 类型前置断言。

## 任务文档
- 详见 `devel/0158.md`