### PR TITLE
[0144] 将 g_rename 类型测试移至 check-report 之前

### DIFF
--- a/devel/0144.md
+++ b/devel/0144.md
@@ -11,7 +11,14 @@ xmake b goldfish
 bin/gf tests/liii/os/rename-test.scm
 ```
 
-预期：测试输出 `12 correct, 0 failed`。
+预期：测试输出 `15 correct, 0 failed`。
+
+## 2026-09-08 将 g_rename 类型测试移至 check-report 之前
+
+### What
+
+1. 将 `tests/liii/os/rename-test.scm` 中 `g_rename` 的 3 个参数类型测试移至 `(check-report)` 之前。
+2. 确保测试断言纳入统计并在断言失败时能通过退出码被 CI 捕获。
 
 ## 2026-09-08 C++ 层为 g_rename 增加参数类型检查
 

--- a/tests/liii/os/rename-test.scm
+++ b/tests/liii/os/rename-test.scm
@@ -108,12 +108,12 @@
 ) ;let*
 
 
-(check-report)
-
-
 ;; ; C 层入口 g_rename 参数类型测试（type-error 为 (liii error) 约定）
 ;; src/dst 必须是 string?，C++ 层需要类型守卫，
 ;; 避免把非字符串对象当作 C 字符串指针导致段错误 (devel/0144.md)
 (check-catch 'type-error (g_rename 1 2))
 (check-catch 'type-error (g_rename "src" 2))
 (check-catch 'type-error (g_rename 1 "dst"))
+
+
+(check-report)


### PR DESCRIPTION
## 概要

在 `tests/liii/os/rename-test.scm` 中，原先新增的 `g_rename` 类型测试写在 `(check-report)` 之后，导致测试统计未能覆盖，且回归失败时无法由 `check-report` 产生非零退出码。

本次改动：
- 将 `tests/liii/os/rename-test.scm` 中 3 条 `g_rename` 类型检查断言移至 `(check-report)` 之前
- 更新 `devel/0144.md` 测试预期为 15 correct 并记录本次提交