### PR TITLE
[0145] 将 g_listdir 类型测试移至 check-report 之前

### DIFF
--- a/devel/0145.md
+++ b/devel/0145.md
@@ -11,7 +11,14 @@ xmake b goldfish
 bin/gf tests/liii/os/listdir-test.scm
 ```
 
-预期：测试输出 `7 correct, 0 failed`。
+预期：测试输出 `10 correct, 0 failed`（Windows 下为 11 correct）。
+
+## 2026-09-08 将 g_listdir 类型测试移至 check-report 之前
+
+### What
+
+1. 将 `tests/liii/os/listdir-test.scm` 中 `g_listdir` 的 3 个参数类型测试移至 `(check-report)` 之前。
+2. 确保测试断言纳入统计并在断言失败时能通过退出码被 CI 捕获。
 
 ## 2026-09-08 C++ 层为 g_listdir 增加参数类型检查
 

--- a/tests/liii/os/listdir-test.scm
+++ b/tests/liii/os/listdir-test.scm
@@ -65,12 +65,12 @@
 ) ;when
 
 
-(check-report)
-
-
 ;; ; C 层入口 g_listdir 参数类型测试
 ;; path 必须是 string?，C++ 层需要类型守卫，
 ;; 避免把非字符串对象当作 C 字符串指针导致崩溃 (devel/0145.md)
 (check-catch 'type-error (g_listdir 99))
 (check-catch 'type-error (g_listdir 'dir))
 (check-catch 'type-error (g_listdir #t))
+
+
+(check-report)


### PR DESCRIPTION
## 概要

在 `tests/liii/os/listdir-test.scm` 中，原先新增的 `g_listdir` 类型测试写在 `(check-report)` 之后，导致测试统计未能覆盖，且回归失败时无法由 `check-report` 产生非零退出码。

本次改动：
- 将 `tests/liii/os/listdir-test.scm` 中 3 条 `g_listdir` 类型检查断言移至 `(check-report)` 之前
- 更新 `devel/0145.md` 测试预期为 10 correct（Windows 下为 11 correct）并记录本次提交