### PR TITLE
[0149] 修复 g_http-post 的 files 参数 multipart 路径类型检查缺失导致的段错误

### DIFF
--- a/devel/0149.md
+++ b/devel/0149.md
@@ -14,9 +14,24 @@ bin/gf tests/liii/http/http-get-test.scm
 bin/gf tests/liii/http/http-post-test.scm
 ```
 
-预期：全部测试通过，0 failed（无网络环境下分别输出 3/9/11 correct, 0 failed）。
+预期：全部测试通过，0 failed（无网络环境下分别输出 3/9/16 correct, 0 failed）。
 
-## 2026-09-08 C++ 层为 http 模块胶水函数增加参数类型检查
+## 2026-09-08 修复 g_http-post 的 files 参数 multipart 路径类型检查缺失
+
+### What
+
+1. `src/liii_http.cpp` 新增 `check_multipart_part_spec` 与 `check_multipart_files`：
+   - 校验 `files` 的每个 part-spec 是 proper list；其内每个 entry 是 pair，key 为 string/symbol，value 为 string。
+2. `f_http_post` 入口处要求 `files` 必须是列表（否则 `type-error`），与 params/headers/proxy 的守卫行为一致；非空时再逐 part-spec 校验。
+3. `tests/liii/http/http-post-test.scm` 离线测试段新增 5 条直接调用 `g_http-post` 的回归用例（files 非列表、part 非列表、entry key 非法、entry value 非字符串、entry cdr 为列表）。
+
+### Why
+
+此前 `f_http_post` 只校验了 `params`/`headers`/`proxy`/`body_or_data`，`files` 非空 proper list 时直接进入 `to_cpr_multipart_part`，其内部对 `s7_car(entry)`、`s7_string(raw_key)`、`s7_string(s7_cdr(entry))` 全部无类型检查。根环境直接调用 `(g_http-post "http://x/" '() '() '() '() '(#\a) #f)` 时，`s7_car(#\a)` 解引用立即数导致 SIGSEGV（与 c32~c39 同一威胁模型）。公开接口 `http-post` 由 `http-normalize-files` 保护，不受影响。另外 `files` 传非列表值（如 `42`、`#f`）此前会被静默忽略并走普通 body 分支，现在统一抛 `type-error`。
+
+## 2026-09-08 之前的提交和任务描述
+
+C++ 层为 http 模块胶水函数增加参数类型检查，修复非法参数导致的崩溃（#972）。
 
 ### What
 

--- a/src/liii_http.cpp
+++ b/src/liii_http.cpp
@@ -171,6 +171,41 @@ to_cpr_multipart_part (s7_scheme* sc, s7_pointer part_spec) {
   return cpr::Part (name, value, content_type);
 }
 
+static bool
+check_multipart_part_spec (s7_scheme* sc, s7_pointer part_spec) {
+  if (!s7_is_list (sc, part_spec)) {
+    return false;
+  }
+  s7_pointer iter= part_spec;
+  while (!s7_is_null (sc, iter)) {
+    s7_pointer entry= s7_car (iter);
+    if (!s7_is_pair (entry)) {
+      return false;
+    }
+    s7_pointer key= s7_car (entry);
+    if (!s7_is_symbol (key) && !s7_is_string (key)) {
+      return false;
+    }
+    if (!s7_is_string (s7_cdr (entry))) {
+      return false;
+    }
+    iter= s7_cdr (iter);
+  }
+  return true;
+}
+
+static bool
+check_multipart_files (s7_scheme* sc, s7_pointer files) {
+  s7_pointer iter= files;
+  while (!s7_is_null (sc, iter)) {
+    if (!check_multipart_part_spec (sc, s7_car (iter))) {
+      return false;
+    }
+    iter= s7_cdr (iter);
+  }
+  return true;
+}
+
 static void
 append_cpr_multipart_file_parts (s7_scheme* sc, s7_pointer files, std::vector<cpr::Part>& parts) {
   s7_pointer iter= files;
@@ -309,13 +344,20 @@ f_http_post (s7_scheme* sc, s7_pointer args) {
   if (!check_string_alist (sc, proxy)) {
     return string_type_error (sc, "http-post: proxy must be an association list of string pairs", proxy);
   }
-  s7_pointer files   = s7_cadr (s7_cddddr (args));
+  s7_pointer files= s7_cadr (s7_cddddr (args));
+  if (!s7_is_list (sc, files)) {
+    return string_type_error (sc, "http-post: files must be a list of multipart part specs", files);
+  }
   s7_pointer callback= s7_list_ref (sc, args, 6);
   if (!s7_is_boolean (callback) && !s7_is_procedure (callback)) {
     return string_type_error (sc, "http-post: callback must be a procedure or boolean", callback);
   }
 
-  if (s7_is_list (sc, files) && !s7_is_null (sc, files)) {
+  if (!s7_is_null (sc, files)) {
+    if (!check_multipart_files (sc, files)) {
+      return string_type_error (
+          sc, "http-post: each files entry must be a list of (key . value) pairs with string values", files);
+    }
     if (!check_string_alist (sc, body_or_data)) {
       return string_type_error (sc, "http-post: multipart data must be an association list of string pairs",
                                 body_or_data);
@@ -340,7 +382,7 @@ f_http_post (s7_scheme* sc, s7_pointer args) {
     session.SetProxies (cpr_proxies);
   }
 
-  if (s7_is_list (sc, files) && !s7_is_null (sc, files)) {
+  if (!s7_is_null (sc, files)) {
     session.SetMultipart (to_cpr_post_multipart (sc, body_or_data, files));
   }
   else {

--- a/tests/liii/http/http-post-test.scm
+++ b/tests/liii/http/http-post-test.scm
@@ -15,6 +15,15 @@
 (check-catch 'type-error (http-post "http://x/" :files 42))
 (check-catch 'type-error (http-post "http://x/" :files '(42)))
 
+;; C 层入口 g_http-post 的 files 参数类型测试 (devel/0149.md)
+;; files 必须是 part-spec 列表；每个 part-spec 是 (key . value) 组成的 proper list，
+;; key 为 string/symbol，value 为 string，否则 C++ 层 s7_car/s7_string 直接解引用导致段错误
+(check-catch 'type-error (g_http-post "http://x/" '() "" '() '() 42 #f))
+(check-catch 'type-error (g_http-post "http://x/" '() '() '() '() '(#\a) #f))
+(check-catch 'type-error (g_http-post "http://x/" '() '() '() '() '((#\a . "v")) #f))
+(check-catch 'type-error (g_http-post "http://x/" '() '() '() '() '(("name" . 42)) #f))
+(check-catch 'type-error (g_http-post "http://x/" '() '() '() '() '(("name" "v")) #f))
+
 ;; 环境检查
 (let ((env (getenv "GOLDFISH_TEST_HTTP")))
   (when (not env)


### PR DESCRIPTION
## What

1. `src/liii_http.cpp` 新增 `check_multipart_part_spec` 与 `check_multipart_files`：
   - 校验 `files` 的每个 part-spec 是 proper list；其内每个 entry 是 pair，key 为 string/symbol，value 为 string。
2. `f_http_post` 入口处要求 `files` 必须是列表（否则 `type-error`），与 params/headers/proxy 的守卫行为一致；非空时再逐 part-spec 校验。
3. `tests/liii/http/http-post-test.scm` 离线测试段新增 5 条直接调用 `g_http-post` 的回归用例（files 非列表、part 非列表、entry key 非法、entry value 非字符串、entry cdr 为列表）。

## Why

此前 `f_http_post` 只校验了 `params`/`headers`/`proxy`/`body_or_data`，`files` 非空 proper list 时直接进入 `to_cpr_multipart_part`，其内部对 `s7_car(entry)`、`s7_string(raw_key)`、`s7_string(s7_cdr(entry))` 全部无类型检查。根环境直接调用 `(g_http-post "http://x/" '() '() '() '() '(#\a) #f)` 时，`s7_car(#\a)` 解引用立即数导致 SIGSEGV（与 c32~c39 同一威胁模型）。公开接口 `http-post` 由 `http-normalize-files` 保护，不受影响。另外 `files` 传非列表值（如 `42`、`#f`）此前会被静默忽略并走普通 body 分支，现在统一抛 `type-error`。

## 测试

```bash
xmake b goldfish
bin/gf tests/liii/http/http-head-test.scm
bin/gf tests/liii/http/http-get-test.scm
bin/gf tests/liii/http/http-post-test.scm
```

预期：全部测试通过，0 failed（无网络环境下分别输出 3/9/16 correct）。