### PR TITLE
[0154] 修复 json-drop 回调期造环死循环及 json-set/reduce 列表截短脏数据问题

### DIFF
--- a/devel/0154.md
+++ b/devel/0154.md
@@ -19,6 +19,12 @@ bin/gf fmt
 for f in tests/liii/json/*.scm; do bin/gf "$f"; done
 ```
 
+## 2026-03-31 复现 json-drop 回调期间造环导致死循环
+
+### What
+1. 在 `tests/liii/json/json-drop-test.scm` 中增加测试用例：在 `json-drop` 遍历 alist 期间通过谓词过程修改链表造环 `(set-cdr! j j)`。
+2. 复现了由于 `json_guenchi_drop` 缺少骨架长度上限限制，在遍历期间成环导致无限死循环（CPU 100% Hang）的问题。
+
 ## 2026-03-31 修复 json-object? 环状死循环、json->string 爆栈 Crash 及 GC 内存越界风险
 ### What
 1. 修复了 `(json-object? x)` 在遇到循环列表（Circular list）时导致无限死循环（CPU 100% Hang）的严重隐患，将内部的 `(list? x)` 替换为 `(proper-list? x)`，连带消除了 `json-contains-key?`、`json-keys` 和 `ensure-json-structure` 在处理环状结构时的死循环风险。

--- a/devel/0154.md
+++ b/devel/0154.md
@@ -19,6 +19,12 @@ bin/gf fmt
 for f in tests/liii/json/*.scm; do bin/gf "$f"; done
 ```
 
+## 2026-03-31 复现 json-set/json-reduce 回调改短列表产生脏数据
+
+### What
+1. 在 `tests/liii/json/json-set-test.scm` 与 `tests/liii/json/json-reduce-test.scm` 中增加测试用例：在回调谓词期间通过 `set-cdr!` 破坏性截短正在遍历的列表。
+2. 复现了由于骨架预分配未走满，导致末尾残留未填充的空骨架 `()`，静默返回 `((a . 1) ())` 脏数据的问题。
+
 ## 2026-03-31 修复 json-drop 回调期间造环导致死循环的问题
 
 ### What

--- a/devel/0154.md
+++ b/devel/0154.md
@@ -19,6 +19,18 @@ bin/gf fmt
 for f in tests/liii/json/*.scm; do bin/gf "$f"; done
 ```
 
+## 2026-03-31 修复 json-drop 回调期间造环导致死循环的问题
+
+### What
+1. 修复了 `json_guenchi_drop` 在遍历 alist 期间缺少遍历步数上限的问题，为其传入链表初始长度 `len`，并在循环条件中增加 `step < len` 防护。
+2. 当用户传入的谓词回调试图通过 `set-cdr!` 修改原链表造环或无限追加节点时，循环至多执行 `len` 步即跳出，避免了死循环挂起（CPU 100% Hang）。
+
+### Why
+`json-set` 与 `json-reduce` 在遍历 alist 时均有骨架链表 `tail` 上限约束，而 `json-drop` 此前直接采用无界的 `while (s7_is_pair (p))`。当用户在谓词中修改链表成环（如 `(set-cdr! j j)`）时，会导致循环永不退出。
+
+### How
+在 `src/liii_json.cpp` 中将 `json_guenchi_drop` 的签名扩展为接收 `s7_int len`，并在遍历循环中加入计数器 `s7_int step = 0` 及 `step < len` 边界判断。
+
 ## 2026-03-31 复现 json-drop 回调期间造环导致死循环
 
 ### What

--- a/devel/0154.md
+++ b/devel/0154.md
@@ -19,6 +19,18 @@ bin/gf fmt
 for f in tests/liii/json/*.scm; do bin/gf "$f"; done
 ```
 
+## 2026-03-31 修复 json-set/json-reduce 回调改短列表抛出 value-error
+
+### What
+1. 修复了 `json_guenchi_set` 和 `json_guenchi_reduce` 在遍历对象 alist 期间原列表被回调破坏性截短时，返回带有空骨架节点 `((a . 1) ())` 脏数据的问题。
+2. 在循环结束后增加 `if (s7_is_pair (tail))` 检查，若原列表被截短导致预分配骨架未被填满，抛出 `value-error`："JSON object modified during iteration"。
+
+### Why
+`json-set` 和 `json-reduce` 具备函数式不可变语义。调用方若在回调谓词中通过 `set-cdr!` 等原地突变操作改变列表长度，属于违背不可变原则的非法操作，应直接抛出 `value-error` 阻止脏数据输出。
+
+### How
+在 `src/liii_json.cpp` 的 `json_guenchi_set` 与 `json_guenchi_reduce` 循环结束后解栈保护后，判断 `s7_is_pair (tail)`，若仍有未填充的骨架节点则通过 `s7_error` 抛出 `value-error`。
+
 ## 2026-03-31 复现 json-set/json-reduce 回调改短列表产生脏数据
 
 ### What

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -1010,6 +1010,10 @@ json_guenchi_set (s7_scheme* sc, s7_pointer x, s7_pointer v, s7_int len, const j
     p   = s7_cdr (p);
   }
   s7_gc_unprotect_via_stack (sc, head);
+  if (s7_is_pair (tail)) {
+    return s7_error (sc, s7_make_symbol (sc, "value-error"),
+                     s7_list (sc, 2, s7_make_string (sc, "JSON object modified during iteration"), x));
+  }
   return head;
 }
 
@@ -1317,6 +1321,10 @@ json_guenchi_reduce (s7_scheme* sc, s7_pointer x, s7_pointer v, const json_reduc
     p   = s7_cdr (p);
   }
   s7_gc_unprotect_via_stack (sc, head);
+  if (s7_is_pair (tail)) {
+    return s7_error (sc, s7_make_symbol (sc, "value-error"),
+                     s7_list (sc, 2, s7_make_string (sc, "JSON object modified during iteration"), x));
+  }
   return head;
 }
 

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -1153,7 +1153,7 @@ glue_json_push (s7_scheme* sc) {
 // guenchi json-drop 的单层语义：x 已校验为 JSON 对象或数组
 // v 为过程时按键（数组为索引）谓词筛选，否则按 equal? 匹配键（数组为索引）
 static s7_pointer
-json_guenchi_drop (s7_scheme* sc, s7_pointer x, s7_pointer v) {
+json_guenchi_drop (s7_scheme* sc, s7_pointer x, s7_pointer v, s7_int len) {
   bool use_pred= s7_is_procedure (v);
   if (s7_is_vector (x)) {
     s7_int      n    = s7_vector_length (x);
@@ -1179,14 +1179,16 @@ json_guenchi_drop (s7_scheme* sc, s7_pointer x, s7_pointer v) {
   }
   // 对象（alist）：删除键命中的条目，未命中的条目复用原序对；命中后从尾向头 cons
   std::vector<s7_pointer> kept;
-  kept.reserve (16);
-  s7_pointer p= x;
-  while (s7_is_pair (p)) {
+  kept.reserve (len > 0 ? len : 16);
+  s7_pointer p   = x;
+  s7_int     step= 0;
+  while (s7_is_pair (p) && step < len) {
     s7_pointer entry= s7_car (p);
     bool       hit  = use_pred ? (s7_call (sc, v, s7_list (sc, 1, s7_car (entry))) != s7_f (sc))
                                : s7_is_equal (sc, s7_car (entry), v);
     if (!hit) kept.push_back (entry);
     p= s7_cdr (p);
+    step++;
   }
   s7_pointer lst= s7_nil (sc);
   s7_gc_on (sc, false);
@@ -1208,7 +1210,7 @@ json_drop_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer keys) {
   if (json_is_null_object (sc, x)) return x;
   if (s7_is_null (sc, s7_cdr (keys))) {
     // 单键
-    return json_guenchi_drop (sc, x, s7_car (keys));
+    return json_guenchi_drop (sc, x, s7_car (keys), len);
   }
   // 多键：经 json-set 的单层语义逐层下钻，叶层对旧值在 C++ 内递归 drop
   json_setter st;

--- a/tests/liii/json/json-drop-test.scm
+++ b/tests/liii/json/json-drop-test.scm
@@ -157,12 +157,26 @@
 
 ;; 长列表 drop 测试（防 GC 回收中间未保护的 pair 导致 Use-After-Free）
 (let* ((len 500)
-       (alist (let loop ((i 0) (acc '()))
+       (alist (let loop
+                ((i 0) (acc '()))
                 (if (= i len)
-                    acc
-                    (loop (+ i 1) (cons (cons (string->symbol (string-append "k" (number->string i))) i) acc)))))
-       (res (json-drop alist (lambda (k) #f))))
+                  acc
+                  (loop (+ i 1)
+                    (cons (cons (string->symbol (string-append "k" (number->string i))) i) acc)
+                  ) ;loop
+                ) ;if
+              ) ;let
+       ) ;alist
+       (res (json-drop alist (lambda (k) #f)))
+      ) ;
   (check (length res) => len)
+) ;let*
+
+;; 迭代期间回调造环导致死循环防护
+(let* ((j (list (cons 'a 1) (cons 'b 2)))
+       (res (json-drop j (lambda (k) (set-cdr! j j) #f)))
+      ) ;
+  (check-true (list? res))
 ) ;let*
 
 (check-report)

--- a/tests/liii/json/json-reduce-test.scm
+++ b/tests/liii/json/json-reduce-test.scm
@@ -202,12 +202,23 @@
 
 ;; 迭代期间列表被谓词修改变长时的越界保护（防止非法写 nil 导致 Crash）
 (let* ((j (list (cons 'a 1) (cons 'b 2)))
-       (res (json-reduce j (lambda (k)
-                             (when (eq? k 'a)
-                               (set-cdr! (cdr j) (list (cons 'c 3))))
-                             #f)
-                         (lambda (k v) v))))
+       (res (json-reduce j
+              (lambda (k) (when (eq? k 'a) (set-cdr! (cdr j) (list (cons 'c 3)))) #f)
+              (lambda (k v) v)
+            ) ;json-reduce
+       ) ;res
+      ) ;
   (check-true (list? res))
 ) ;let*
+
+;; 迭代期间列表被谓词修改改短时抛出 value-error（防止残留未填充骨架）
+(check-catch 'value-error
+  (let ((j (list (cons 'a 1) (cons 'b 2))))
+    (json-reduce j
+      (lambda (k) (when (eq? k 'a) (set-cdr! j '())) #f)
+      (lambda (k v) v)
+    ) ;json-reduce
+  ) ;let
+) ;check-catch
 
 (check-report)

--- a/tests/liii/json/json-set-test.scm
+++ b/tests/liii/json/json-set-test.scm
@@ -194,12 +194,20 @@
 
 ;; 迭代期间列表被谓词修改变长时的越界保护（防止非法写 nil 导致 Crash）
 (let* ((j (list (cons 'a 1) (cons 'b 2)))
-       (res (json-set j (lambda (k)
-                          (when (eq? k 'a)
-                            (set-cdr! (cdr j) (list (cons 'c 3))))
-                          #f)
-                      0)))
+       (res (json-set j
+              (lambda (k) (when (eq? k 'a) (set-cdr! (cdr j) (list (cons 'c 3)))) #f)
+              0
+            ) ;json-set
+       ) ;res
+      ) ;
   (check-true (list? res))
 ) ;let*
+
+;; 迭代期间列表被谓词修改改短时抛出 value-error（防止残留未填充骨架）
+(check-catch 'value-error
+  (let ((j (list (cons 'a 1) (cons 'b 2))))
+    (json-set j (lambda (k) (when (eq? k 'a) (set-cdr! j '())) #f) 0)
+  ) ;let
+) ;check-catch
 
 (check-report)


### PR DESCRIPTION
## 概要

排查并修复 `(liii json)` 在遍历期间被破坏性篡改原列表结构的边界隐患：

1. **`json-drop` 回调造环死循环防御**：
   - 复现：谓词回调期间执行 `(set-cdr! j j)` 造环导致 `while (s7_is_pair (p))` 无限死循环超时（Hang）。
   - 修复：为 `json_guenchi_drop` 引入初始长度 `len`，在遍历对象 alist 时增加 `step < len` 边界限制。

2. **`json-set` / `json-reduce` 列表截短脏数据防御**：
   - 复现：回调谓词期间执行 `(set-cdr! j '())` 破坏性截短列表，预分配骨架未被填满，导致末尾残留未填充的空骨架 `()`，静默返回 `((a . 1) ())`。
   - 修复：循环结束后增加 `if (s7_is_pair (tail))` 校验，检测到原列表在迭代期间被截短时抛出 `value-error`，符合不可变（immutable）语义。

3. 同步更新 `devel/0154.md` 并补充全套 TDD 回归测试用例。