### PR TITLE
[0145] 补充 g_listdir 空字符串参数防越界读回归测试

### DIFF
--- a/devel/0145.md
+++ b/devel/0145.md
@@ -11,7 +11,13 @@ xmake b goldfish
 bin/gf tests/liii/os/listdir-test.scm
 ```
 
-预期：测试输出 `10 correct, 0 failed`（Windows 下为 11 correct）。
+预期：测试输出 `11 correct, 0 failed`（Windows 下为 12 correct）。
+
+## 2026-09-08 补充 g_listdir 空字符串参数防越界读回归测试
+
+### What
+
+1. 在 `tests/liii/os/listdir-test.scm` 中补充 `(check (g_listdir "") => #())` 回归测试用例，覆盖空字符串参数防负下标越界读取的场景。
 
 ## 2026-09-08 将 g_listdir 类型测试移至 check-report 之前
 

--- a/tests/liii/os/listdir-test.scm
+++ b/tests/liii/os/listdir-test.scm
@@ -72,5 +72,9 @@
 (check-catch 'type-error (g_listdir 'dir))
 (check-catch 'type-error (g_listdir #t))
 
+;; ; 空字符串路径防越界读取回归测试 (devel/0145.md)
+(check (g_listdir "") => #())
+
+
 
 (check-report)


### PR DESCRIPTION
## 概要

在 `src/liii_os.cpp` 的 `f_listdir` 中，先前修复了 `path_s[path_N - 1]` 对空字符串 `""` 的负下标越界读取未定义行为（UB），但测试中缺少对 `(g_listdir "")` 的回归测试。

本次改动：
- 在 `tests/liii/os/listdir-test.scm` 中补充 `(check (g_listdir "") => #())` 回归测试
- 更新 `devel/0145.md` 预期结果为 11 correct（Windows 下为 12 correct）并记录本次提交