### PR TITLE
[0152] 修复 substring/cursors 索引路径 start 索引越界读内存导致的段错误

### DIFF
--- a/devel/0152.md
+++ b/devel/0152.md
@@ -2,24 +2,32 @@
 
 ## 任务相关的代码文件
 - src/liii_string_cursor.cpp
-- demo/crash/c42-string-cursor-prev-oob.scm
-- demo/crash/c43-string-cursor-back-oob.scm
-- demo/crash/c44-string-cursor-diff-oob.scm
-- demo/crash/c45-string-cursor-forward-negative-oob.scm
+- tests/liii/string-cursor/
 - devel/0152.md
 
 ## 如何测试
 ```bash
 xmake b goldfish
-bin/gf demo/crash/c42-string-cursor-prev-oob.scm
-bin/gf demo/crash/c43-string-cursor-back-oob.scm
-bin/gf demo/crash/c44-string-cursor-diff-oob.scm
-bin/gf demo/crash/c45-string-cursor-forward-negative-oob.scm
+bin/gf fmt
+for f in tests/liii/string-cursor/*.scm; do bin/gf "$f"; done
 ```
 
-预期：均抛出规范的 `value-error`，进程不再发生 SIGSEGV 段错误。
+预期：全部测试通过，0 failed，进程不再发生 SIGSEGV 段错误。
 
-## 2026-09-08 修复 (liii string-cursor) 模块游标越界崩溃问题 (c42, c43, c44, c45)
+## 2026-09-08 修复 substring/cursors 索引路径 start 索引越界读
+
+### What
+
+1. `src/liii_string_cursor.cpp`：`f_substring_cursors` 索引模式下 `byte_start` 前进循环补齐 `>= len` 守卫（与 `byte_end` 循环一致），start 索引超过字符数时立即抛 `value-error`。
+2. `tests/liii/string-cursor/substring-slash-cursors-test.scm` 新增 3 条直接调用 `g_substring/cursors` 的回归用例（ASCII、多字节、超大 start 索引）。
+
+### Why
+
+[0152] 第一次提交只修了 `f_substring_cursors` 的游标分支，索引分支的 `byte_start` 循环漏掉了 `>= len` 检查。根环境直接调用 `(g_substring/cursors "ab" 100000000 0)` 时，`utf8_advance` 会持续越界读堆内存，实测触发 SIGSEGV 核心转储（修复前已复现）。公开接口 `substring/cursors` 因 `validate-start-end` 强制 `start <= end`，且 `byte_end` 循环先报错，无法触发该路径。
+
+## 2026-09-08 之前的提交和任务描述
+
+修复 (liii string-cursor) 模块游标越界崩溃问题 (c42, c43, c44, c45)。
 
 ### What
 

--- a/src/liii_string_cursor.cpp
+++ b/src/liii_string_cursor.cpp
@@ -417,8 +417,10 @@ f_substring_cursors (s7_scheme* sc, s7_pointer args) {
       byte_end= utf8_advance (s, byte_end);
     }
     byte_start= 0;
-    for (s7_int i= 0; i < ia; i++)
+    for (s7_int i= 0; i < ia; i++) {
+      if (byte_start >= len) return liii_string_cursor_value_error (sc, "substring/cursors: start index out of range");
       byte_start= utf8_advance (s, byte_start);
+    }
   }
   if (byte_start > byte_end || byte_end > len)
     return liii_string_cursor_value_error (sc, "substring/cursors: end index out of range");

--- a/tests/liii/string-cursor/substring-slash-cursors-test.scm
+++ b/tests/liii/string-cursor/substring-slash-cursors-test.scm
@@ -86,4 +86,11 @@
 
 ;; 测试混合 index/cursor 参数应该报错
 (check-catch 'type-error (substring/cursors "abc" 0 (string-cursor-end "abc")))
+
+;; C 层入口 g_substring/cursors 索引路径越界防护测试 (devel/0152.md)
+;; 索引模式下 byte_start 前进循环必须有 >= len 守卫，
+;; 否则 start 超过字符数时会越界读内存（大 start 还会长时间空转甚至段错误）
+(check-catch 'value-error (g_substring/cursors "ab" 4 2))
+(check-catch 'value-error (g_substring/cursors "中文" 3 2))
+(check-catch 'value-error (g_substring/cursors "ab" 100000000 0))
 (check-report)


### PR DESCRIPTION
## What

1. `src/liii_string_cursor.cpp`：`f_substring_cursors` 索引模式下 `byte_start` 前进循环补齐 `>= len` 守卫（与 `byte_end` 循环一致），start 索引超过字符数时立即抛 `value-error`。
2. `tests/liii/string-cursor/substring-slash-cursors-test.scm` 新增 3 条直接调用 `g_substring/cursors` 的回归用例（ASCII、多字节、超大 start 索引）。
3. `devel/0152.md`：修正已过时的测试命令（demo/crash 已删除），补充本次修复记录。

## Why

[0152] 第一次提交只修了 `f_substring_cursors` 的游标分支，索引分支的 `byte_start` 循环漏掉了 `>= len` 检查。根环境直接调用 `(g_substring/cursors "ab" 100000000 0)` 时，`utf8_advance` 持续越界读堆内存，**修复前已复现 SIGSEGV 核心转储**。公开接口 `substring/cursors` 因 `validate-start-end` 强制 `start <= end` 且 `byte_end` 循环先报错，无法触发该路径。

## 测试

```bash
xmake b goldfish
for f in tests/liii/string-cursor/*.scm; do bin/gf "$f"; done
```

预期：全部通过，0 failed。