### PR TITLE
[0157] 规范化 reverse-vector->list 错误类型并清理 s7 死代码

### DIFF
--- a/devel/0157.md
+++ b/devel/0157.md
@@ -2,6 +2,7 @@
 
 ## 任务相关的代码文件
 - src/s7.c
+- src/s7_internal.h
 - src/s7_liii_vector.c
 - goldfish/scheme/base.scm
 - goldfish/srfi/srfi-133.scm
@@ -25,6 +26,18 @@ bin/gf tests/liii/vector/reverse-vector-to-list-test.scm
 ```
 
 预期：全部测试用例通过，0 failed。
+
+## 2026-09-08 规范化 reverse-vector->list 类型错误并清理 s7.c 死代码
+
+### What
+1. 在 `goldfish/srfi/srfi-133.scm` 中，将 `reverse-vector->list` 的三处 `wrong-type-arg` 错误抛出对齐 Goldfish 规范修改为 `type-error`。
+2. 修复 `reverse-vector->list` 的 `end` 可选参数默认值，避免在第一参数非 vector 时提前在参数求值阶段触发底层 `wrong-type-arg`。
+3. 在 `tests/liii/vector/reverse-vector-to-list-test.scm` 中将对应的 `wrong-type-arg` 校验更新为 `type-error`。
+4. 在 `src/s7.c` 和 `src/s7_internal.h` 中彻底清理无调用点的死代码 `find_matching_ref` 以及未被选用的 `g_fv_set_unchecked` 和 `sc->fv_set_unchecked`。
+
+### Why
+1. 根据 Goldfish Scheme 错误体系规范，代码中优先使用 `type-error` 替代历史遗留的 `wrong-type-arg`。
+2. 此前修复 `float-vector-set!` 条件分支越界写问题后，投机优化的扫描辅助函数 `find_matching_ref` 与无检查赋值 `fv_set_unchecked` 已无任何调用与选用点，属于冗余死代码，清理以维护代码卫生。
 
 ## 2026-09-08 修复 reverse-vector->list 参数边界校验缺失问题
 

--- a/goldfish/srfi/srfi-133.scm
+++ b/goldfish/srfi/srfi-133.scm
@@ -404,18 +404,18 @@
       ) ;let
     ) ;define
 
-    (define* (reverse-vector->list vec (start 0) (end (vector-length vec)))
+    (define* (reverse-vector->list vec
+               (start 0)
+               (end (if (vector? vec) (vector-length vec) 0))
+             ) ;reverse-vector->list
       (unless (vector? vec)
-        (error 'wrong-type-arg
-          "reverse-vector->list: first argument must be a vector"
-          vec
-        ) ;error
+        (error 'type-error "reverse-vector->list: first argument must be a vector" vec)
       ) ;unless
       (unless (integer? start)
-        (error 'wrong-type-arg "reverse-vector->list: start must be an integer" start)
+        (error 'type-error "reverse-vector->list: start must be an integer" start)
       ) ;unless
       (unless (integer? end)
-        (error 'wrong-type-arg "reverse-vector->list: end must be an integer" end)
+        (error 'type-error "reverse-vector->list: end must be an integer" end)
       ) ;unless
       (let ((len (vector-length vec)))
         (when (or (< start 0) (> start len))

--- a/src/s7.c
+++ b/src/s7.c
@@ -1399,7 +1399,7 @@ struct s7_scheme {
   s7_pointer add_1x, add_2, add_3, add_4, add_i_random, add_x1, append_2, ash_ic, ash_ii, bv_ref_2, bv_ref_3, bv_set_3,
              cdr_let_ref, cdr_let_set, char_equal_2, char_greater_2, char_less_2, char_position_csi, complex_wrapped, curlet_ref, cv_ref_2, cv_set_3,
              display_2, display_f, dynamic_wind_body, dynamic_wind_init, dynamic_wind_unchecked,
-             format_as_objstr, format_f, format_just_control_string, format_no_column, fv_ref_2, fv_ref_3, fv_set_3, fv_set_unchecked, geq_2,
+             format_as_objstr, format_f, format_just_control_string, format_no_column, fv_ref_2, fv_ref_3, fv_set_3, geq_2,
              get_output_string_uncopied, hash_table_2, hash_table_ref_2, int_log2, is_defined_in_rootlet, is_defined_in_unlet, iv_ref_2, iv_ref_3, iv_set_3,
              list_0, list_1, list_2, list_3, list_4, list_ref_at_0, list_ref_at_1, list_ref_at_2, list_set_i,
              logand_2, logand_ii, logior_ii, logior_2, logxor_2, memq_2, memq_3, memq_4, memq_any, multiply_3,
@@ -25478,43 +25478,6 @@ static s7_pointer g_fv_set_3(s7_scheme *sc, s7_pointer args)
     float_vector(fv, ind) = s7_real(value);
     return(value);
   }
-}
-
-static s7_pointer g_fv_set_unchecked(s7_scheme *sc, s7_pointer args)
-{
-  const s7_pointer fv = car(args), value = caddr(args);
-  s7_int ind;
-  if (!is_real(value))
-    wrong_type_error_nr(sc, sc->float_vector_set_symbol, 3, value, sc->type_names[T_REAL]);
-  if (is_immutable_vector(fv))
-    immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->float_vector_set_symbol, fv));
-  ind = s7_integer_clamped_if_gmp(sc, cadr(args));
-  float_vector(fv, ind) = s7_real(value);
-  return(value);
-}
-
-static bool find_matching_ref(s7_scheme *sc, const s7_pointer getter, s7_pointer expr)
-{
-  /* expr: (*set! v i val), val exists (i.e. args=3, so cddddr is null) */
-  const s7_pointer sym = cadr(expr), ind = caddr(expr);
-  if ((is_symbol(sym)) && (!is_pair(ind)))
-    {
-      const s7_pointer val = cadddr(expr);
-      if (is_optimized(val)) /* includes is_pair */
-	for (s7_pointer p = val; is_pair(p); p = cdr(p))
-	  if (is_pair(car(p)))
-	    {
-	      const s7_pointer ref = car(p);
-	      if (((car(ref) == getter) &&             /* (getter sym ind) */
-		   (is_proper_list_2(sc, cdr(ref))) &&
-		   (cadr(ref) == sym) &&
-		   (caddr(ref) == ind)) ||
-		  ((car(ref) == sym) &&                /* (sym ind) */
-		   (is_proper_list_1(sc, cdr(ref))) &&
-		   (cadr(ref) == ind)))
-		return(true);                          /* else keep looking */
-	    }}
-  return(false);
 }
 
 static s7_pointer float_vector_set_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer unused_expr)
@@ -53818,7 +53781,6 @@ static void init_choosers(s7_scheme *sc)
   /* float-vector-set */
   func = set_function_chooser(sc->float_vector_set_symbol, float_vector_set_chooser);
   sc->fv_set_3 = make_function_with_class(sc, func, "float-vector-set!", g_fv_set_3, 3, 0, false);
-  sc->fv_set_unchecked = make_function_with_class(sc, func, "float-vector-set!", g_fv_set_unchecked, 3, 0, false);
 
   /* int-vector-ref */
   func = set_function_chooser(sc->int_vector_ref_symbol, int_vector_ref_chooser);

--- a/src/s7_internal.h
+++ b/src/s7_internal.h
@@ -1415,7 +1415,7 @@ struct s7_scheme {
   s7_pointer add_1x, add_2, add_3, add_4, add_i_random, add_x1, append_2, ash_ic, ash_ii, bv_ref_2, bv_ref_3, bv_set_3,
              cdr_let_ref, cdr_let_set, char_equal_2, char_greater_2, char_less_2, char_position_csi, complex_wrapped, curlet_ref, cv_ref_2, cv_set_3,
              display_2, display_f, dynamic_wind_body, dynamic_wind_init, dynamic_wind_unchecked,
-             format_as_objstr, format_f, format_just_control_string, format_no_column, fv_ref_2, fv_ref_3, fv_set_3, fv_set_unchecked, geq_2,
+             format_as_objstr, format_f, format_just_control_string, format_no_column, fv_ref_2, fv_ref_3, fv_set_3, geq_2,
              get_output_string_uncopied, hash_table_2, hash_table_ref_2, int_log2, is_defined_in_rootlet, is_defined_in_unlet, iv_ref_2, iv_ref_3, iv_set_3,
              list_0, list_1, list_2, list_3, list_4, list_ref_at_0, list_ref_at_1, list_ref_at_2, list_set_i,
              logand_2, logand_ii, logior_ii, logior_2, logxor_2, memq_2, memq_3, memq_4, memq_any, multiply_3,

--- a/tests/liii/vector/reverse-vector-to-list-test.scm
+++ b/tests/liii/vector/reverse-vector-to-list-test.scm
@@ -42,7 +42,7 @@
 ;; 错误处理
 ;; ----
 ;; out-of-range 当start/end超出向量边界或start大于end时
-;; wrong-type-arg 当vec不是向量，或start/end不是整数时
+;; type-error 当vec不是向量，或start/end不是整数时
 
 
 (check (reverse-vector->list #()) => ())
@@ -78,9 +78,9 @@
 ) ;let
 
 
-(check-catch 'wrong-type-arg (reverse-vector->list 'not-a-vector))
-(check-catch 'wrong-type-arg (reverse-vector->list #(1 2 3) 'not-a-number))
-(check-catch 'wrong-type-arg (reverse-vector->list #(1 2 3) 0 'not-a-number))
+(check-catch 'type-error (reverse-vector->list 'not-a-vector))
+(check-catch 'type-error (reverse-vector->list #(1 2 3) 'not-a-number))
+(check-catch 'type-error (reverse-vector->list #(1 2 3) 0 'not-a-number))
 
 
 (check-report)


### PR DESCRIPTION
## 变更内容

1. **规范化 `reverse-vector->list` 错误类型** (`goldfish/srfi/srfi-133.scm`)：
   - 将 `reverse-vector->list` 中的三处 `wrong-type-arg` 错误抛出对齐规范修改为 `type-error`；
   - 修复 `end` 可选参数默认值，避免在第一参数非向量时提前在参数求值阶段触发底层 `wrong-type-arg`。
2. **更新单元测试** (`tests/liii/vector/reverse-vector-to-list-test.scm`)：
   - 将对应测试用例断言修改为 `type-error`，测试全部通过（23 correct, 0 failed）。
3. **清理死代码与结构体字段** (`src/s7.c`, `src/s7_internal.h`)：
   - 移除无调用点的辅助函数 `find_matching_ref`；
   - 移除未被选用的 `g_fv_set_unchecked` 函数及 `sc->fv_set_unchecked` 字段与初始化。
4. **更新开发文档** (`devel/0157.md`)。

## 测试验证
```bash
xmake b goldfish
bin/gf fmt
bin/gf test tests/liii/vector/
```
所有测试均通过（64 passed）。