### PR TITLE
[0152] 优化 substring/cursors 越界报错为 out-of-range 并测试公开接口

### DIFF
--- a/devel/0152.md
+++ b/devel/0152.md
@@ -14,6 +14,13 @@ for f in tests/liii/string-cursor/*.scm; do bin/gf "$f"; done
 
 预期：全部测试通过，0 failed，进程不再发生 SIGSEGV 段错误。
 
+## 2026-09-08 优化 substring/cursors 越界报错为 out-of-range 并测试公开接口
+
+### What
+
+1. `src/liii_string_cursor.cpp`：`f_substring_cursors` 索引模式优化为先推进 `byte_start` 再推进 `byte_end`，并将越界错误类型由 `value-error` 规范调整为 `out-of-range`。
+2. `tests/liii/string-cursor/substring-slash-cursors-test.scm`：去除直接调用底层原语 `g_substring/cursors` 的测试，改为通过公开接口 `substring/cursors` 测试索引越界抛出 `out-of-range`。
+
 ## 2026-09-08 修复 substring/cursors 索引路径 start 索引越界读
 
 ### What

--- a/src/liii_string_cursor.cpp
+++ b/src/liii_string_cursor.cpp
@@ -411,19 +411,22 @@ f_substring_cursors (s7_scheme* sc, s7_pointer args) {
       return liii_string_cursor_out_of_range_error (sc, "substring/cursors: end cursor out of range", b);
   }
   else {
-    byte_end= 0;
-    for (s7_int i= 0; i < ib; i++) {
-      if (byte_end >= len) return liii_string_cursor_value_error (sc, "substring/cursors: end index out of range");
-      byte_end= utf8_advance (s, byte_end);
-    }
+    if (ia > ib) return liii_string_cursor_value_error (sc, "substring/cursors: start must be <= end");
     byte_start= 0;
     for (s7_int i= 0; i < ia; i++) {
-      if (byte_start >= len) return liii_string_cursor_value_error (sc, "substring/cursors: start index out of range");
+      if (byte_start >= len)
+        return liii_string_cursor_out_of_range_error (sc, "substring/cursors: start index out of range", a);
       byte_start= utf8_advance (s, byte_start);
     }
+    byte_end= byte_start;
+    for (s7_int i= ia; i < ib; i++) {
+      if (byte_end >= len)
+        return liii_string_cursor_out_of_range_error (sc, "substring/cursors: end index out of range", b);
+      byte_end= utf8_advance (s, byte_end);
+    }
   }
-  if (byte_start > byte_end || byte_end > len)
-    return liii_string_cursor_value_error (sc, "substring/cursors: end index out of range");
+  if (byte_start > byte_end) return liii_string_cursor_value_error (sc, "substring/cursors: start must be <= end");
+  if (byte_end > len) return liii_string_cursor_out_of_range_error (sc, "substring/cursors: end index out of range", b);
 
   s7_pointer result= s7_make_string_with_length (sc, "", byte_end - byte_start);
   memcpy ((char*) s7_string (result), s + byte_start, byte_end - byte_start);

--- a/tests/liii/string-cursor/substring-slash-cursors-test.scm
+++ b/tests/liii/string-cursor/substring-slash-cursors-test.scm
@@ -87,10 +87,9 @@
 ;; 测试混合 index/cursor 参数应该报错
 (check-catch 'type-error (substring/cursors "abc" 0 (string-cursor-end "abc")))
 
-;; C 层入口 g_substring/cursors 索引路径越界防护测试 (devel/0152.md)
-;; 索引模式下 byte_start 前进循环必须有 >= len 守卫，
-;; 否则 start 超过字符数时会越界读内存（大 start 还会长时间空转甚至段错误）
-(check-catch 'value-error (g_substring/cursors "ab" 4 2))
-(check-catch 'value-error (g_substring/cursors "中文" 3 2))
-(check-catch 'value-error (g_substring/cursors "ab" 100000000 0))
+;; 索引越界防护测试：应抛出 out-of-range 错误 (devel/0152.md)
+(check-catch 'out-of-range (substring/cursors "ab" 4 5))
+(check-catch 'out-of-range (substring/cursors "中文" 3 3))
+(check-catch 'out-of-range (substring/cursors "ab" 0 4))
+(check-catch 'out-of-range (substring/cursors "ab" 100000000 100000000))
 (check-report)


### PR DESCRIPTION
## 概要

优化 `substring/cursors` 的越界错误类型和单元测试：

1. **统一错误类型为 `out-of-range`**：
   - 索引模式下的越界错误此前误报为 `value-error`，统一调整为使用 `liii_string_cursor_out_of_range_error` 抛出规范的 `'out-of-range` 错误（与游标模式及 `(scheme base)` 保持一致）。

2. **遍历顺序优化与单向推进**：
   - 先推进 `byte_start`，并在前进时做 `byte_start >= len` 守卫；
   - `byte_end` 从 `byte_start` 继续推进，避免了重复从 0 遍历，且让公开接口在 `start <= end` 的前提下即可直接触发 start 越界守卫。

3. **测试仅调用公开 API**：
   - 移除测试中直接调用私有原语 `g_substring/cursors` 的代码，全部通过公开接口 `(substring/cursors ...)` 进行回归验证，断言捕获 `'out-of-range`。

4. 更新 `devel/0152.md` 记录本次改进。