### PR TITLE
[0151] 修复 subprocess 模块 env alist 环形结构导致的死循环挂起

### DIFF
--- a/devel/0151.md
+++ b/devel/0151.md
@@ -17,6 +17,16 @@ bin/gf tests/liii/subprocess/run-values-test.scm
 
 预期：全部测试通过，0 failed。
 
+## 2026-09-08 修复 subprocess 模块 env alist 环形结构导致的死循环挂起
+
+### What
+1. 在 `src/liii_subprocess.cpp` 的 `f_subprocess_run_values` 中增加 `s7_is_proper_list (sc, env_arg)` 环检测，遇到环形列表或点对时在进入遍历循环前直接抛出 `type-error`。
+2. 在 `goldfish/liii/subprocess.scm` 的 `%valid-env?` 谓词中，将 `(list? env)` 替换为 `(proper-list? env)`，使公开 API `(run-values "true" :env cyclic-env)` 也能在 Scheme 层前置拦截环形列表。
+3. 在 `tests/liii/subprocess/run-values-test.scm` 中增加环形 env 结构的回归测试用例，覆盖公开接口与底层 `g_subprocess-run-values` 调用。
+
+### Why
+`f_subprocess_run_values` 原实现使用 `while (s7_is_pair (env_alist))` 遍历环境变量列表，并在循环末尾检查 `!s7_is_null`。若传入自引用/成环的 alist，循环条件永远满足，导致进程陷入无限死循环（CPU 100% Hang）无法终止。
+
 ## 2026-09-08 修复 (liii subprocess) 中的崩溃问题 (c40, c41)
 
 ### What

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -239,7 +239,7 @@
 
     (define (%valid-env? env)
       (or (not env)
-        (and (list? env)
+        (and (proper-list? env)
           (every (lambda (x) (and (pair? x) (string? (car x)) (string? (cdr x)))) env)
         ) ;and
       ) ;or

--- a/src/liii_subprocess.cpp
+++ b/src/liii_subprocess.cpp
@@ -62,6 +62,9 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
     if (!s7_is_pair (env_arg)) {
       return subprocess_type_error (sc, "g_subprocess-run-values: env must be an alist", env_arg);
     }
+    if (!s7_is_proper_list (sc, env_arg)) {
+      return subprocess_type_error (sc, "g_subprocess-run-values: env must be a proper list", env_arg);
+    }
     s7_pointer env_alist= env_arg;
     while (s7_is_pair (env_alist)) {
       s7_pointer item= s7_car (env_alist);

--- a/tests/liii/subprocess/run-values-test.scm
+++ b/tests/liii/subprocess/run-values-test.scm
@@ -258,4 +258,11 @@
 (check-catch 'type-error (run-values "true" :env '(42)))
 (check-catch 'type-error (run-values "true" :env 42))
 
+;; 环形 env 防御回归测试
+(let ((cyclic-env (list (cons "KEY" "val"))))
+  (set-cdr! cyclic-env cyclic-env)
+  (check-catch 'type-error (run-values "true" :env cyclic-env))
+  (check-catch 'type-error (g_subprocess-run-values '("true") #f cyclic-env))
+) ;let
+
 (check-report)


### PR DESCRIPTION
## 变更内容

1. **C++ 胶水层增加环检测** (`src/liii_subprocess.cpp`)：
   - 在 `f_subprocess_run_values` 遍历 `env_alist` 之前，增加 `s7_is_proper_list (sc, env_arg)` 检测，遇到环形列表或点对列表时提前抛出 `type-error`，避免 `while (s7_is_pair (env_alist))` 陷入无限循环挂起。
2. **Scheme 包装层同步加固** (`goldfish/liii/subprocess.scm`)：
   - 将 `%valid-env?` 中的 `(list? env)` 替换为 `(proper-list? env)`，使公开 API 同样具备前置环检测能力。
3. **补充回归测试** (`tests/liii/subprocess/run-values-test.scm`)：
   - 增加环形 env 结构的回归测试用例，覆盖公开接口与底层 `g_subprocess-run-values`。
4. **更新开发文档** (`devel/0151.md`)。

## 测试验证
```bash
xmake b goldfish
bin/gf fmt
bin/gf test tests/liii/subprocess
```
所有 14 个测试用例均通过。