### PR TITLE
[0156] 补充 delete-duplicates 比较器类型不匹配的语义变化说明与测试

### DIFF
--- a/devel/0156.md
+++ b/devel/0156.md
@@ -29,6 +29,12 @@ bin/gf tests/liii/list/list-not-null-p-test.scm
 bin/gf tests/liii/list/delete-duplicates-test.scm
 ```
 
+## 2026-09-08 补充 delete-duplicates 比较器类型不匹配的语义变化说明与测试
+
+### What
+1. 在 `tests/liii/list/delete-duplicates-test.scm` 中新增 3 条用例，固化当前行为：比较器与元素类型不匹配时（如 `(delete-duplicates (list 1 "a" 1) =)`），不匹配的元素被静默保留而不报错。
+2. 记录该可观察语义变化：哈希优化修复前走 O(n^2) 扫描路径，`(= 1 "a")` 会抛 `wrong-type-arg`；修复后走哈希路径，s7 的哈希 checker 对类型不匹配的键视为"未找到"，元素被保留。SRFI-1 对比较器域错误未作规定，该行为可接受。
+
 ## 2026-08-18 修复 iota_list 末次迭代有符号溢出 UB
 
 ### What

--- a/tests/liii/list/delete-duplicates-test.scm
+++ b/tests/liii/list/delete-duplicates-test.scm
@@ -66,5 +66,11 @@
   #t
 ) ;check
 
+;; 比较器与元素类型不匹配时，哈希路径下不匹配的元素静默保留（不报错）(devel/0156.md)
+;; 注意：这是哈希优化带来的语义变化，修复前走 O(n^2) 扫描路径会抛 wrong-type-arg
+(check (delete-duplicates (list 1 "a" 1) =) => (list 1 "a"))
+(check (delete-duplicates (list "a" 1 "a") string=?) => (list "a" 1))
+(check (delete-duplicates (list #\a 1 #\a) char=?) => (list #\a 1))
+
 
 (check-report)


### PR DESCRIPTION
## What

1. `tests/liii/list/delete-duplicates-test.scm` 新增 3 条用例，固化当前行为：比较器与元素类型不匹配时（如 `(delete-duplicates (list 1 "a" 1) =)`），不匹配的元素被静默保留而不报错。
2. `devel/0156.md` 记录该可观察语义变化。

## Why

哈希优化修复（0156）前走 O(n^2) 扫描路径，`(= 1 "a")` 会抛 `wrong-type-arg`；修复后走哈希路径，s7 的哈希 checker 对类型不匹配的键视为"未找到"，元素被静默保留。SRFI-1 对比较器域错误未作规定，该行为可接受，但属于可观察的行为变化，此前既无文档记录也无测试覆盖，本次补齐。

## 测试

```bash
bin/gf tests/liii/list/delete-duplicates-test.scm
```

预期：17 correct, 0 failed。