### PR TITLE
[0158] 补齐 hash-table-ref/default 与 update! 等函数类型检查

### DIFF
--- a/devel/0158.md
+++ b/devel/0158.md
@@ -6,6 +6,11 @@
 - tests/liii/hash-table/make-hash-table-test.scm
 - tests/liii/hash-table/hash-table-for-each-test.scm
 - tests/liii/hash-table/hash-table-ref-slash-default-test.scm
+- tests/liii/hash-table/hash-table-update-bang-test.scm
+- tests/liii/hash-table/hash-table-update-bang-slash-default-test.scm
+- tests/liii/hash-table/hash-table-contains-p-test.scm
+- tests/liii/hash-table/hash-table-find-test.scm
+- tests/liii/hash-table/hash-table-fold-test.scm
 - tests/liii/hash-table/hash-table-keys-test.scm
 - tests/liii/hash-table/hash-table-values-test.scm
 - tests/liii/hash-table/hash-table-clear-bang-test.scm
@@ -15,9 +20,28 @@
 ```bash
 xmake b goldfish
 bin/gf fmt
-bin/gf tests/liii/hash-table/make-hash-table-test.scm
-bin/gf tests/liii/hash-table/hash-table-for-each-test.scm
+bin/gf tests/liii/hash-table/hash-table-ref-slash-default-test.scm
+bin/gf tests/liii/hash-table/hash-table-update-bang-slash-default-test.scm
+bin/gf tests/liii/hash-table/hash-table-find-test.scm
+bin/gf tests/liii/hash-table/hash-table-fold-test.scm
 ```
+
+## 2026-09-08 补齐 hash-table-ref/default 与 update! 等函数类型检查
+
+### What
+1. 在 `goldfish/srfi/srfi-125.scm` 中为以下函数补充参数类型前置检查：
+   - `hash-table-ref/default`：增加 `(assert-hash-table-type ht hash-table-ref/default)`
+   - `hash-table-update!`：增加 `(assert-hash-table-type ht hash-table-update!)`
+   - `hash-table-update!/default`：增加 `(assert-hash-table-type ht hash-table-update!/default)`，并增加 `(when (not (procedure? updater)) ...)` 校验
+   - `hash-table-find`：增加 `(when (not (procedure? proc)) ...)` 校验
+   - `hash-table-fold`：增加 `(when (not (procedure? proc)) ...)` 校验
+2. 在对应单元测试中补充非哈希表及非过程参数时触发 `type-error` 的断言测试。
+
+### Why
+此前这些函数未进行充分的类型检查，当向 `hash-table-ref/default` 传入非哈希表时会穿透至底层 s7 抛出 `wrong-type-arg`；向空表调用 `hash-table-find` 或 `hash-table-fold` 传入非过程对象时会因未触发查找或折叠而直接静默返回 `failure` 或 `seed`，违背了类型安全规范。
+
+### How
+在函数入口处增加统一的 `assert-hash-table-type` 与 `procedure?` 校验，未通过时统一抛出 `type-error`。
 
 ## 2026-09-08 为 hash-table-keys/values/clear! 等补充类型前置断言
 

--- a/goldfish/srfi/srfi-125.scm
+++ b/goldfish/srfi/srfi-125.scm
@@ -80,6 +80,7 @@
     ) ;define
 
     (define (hash-table-ref/default ht key default)
+      (assert-hash-table-type ht hash-table-ref/default)
       (or (hash-table-ref ht key)
         (if (and (procedure? default) (aritable? default 0)) (default) default)
       ) ;or
@@ -111,10 +112,18 @@
     ) ;define
 
     (define (hash-table-update! ht key value)
+      (assert-hash-table-type ht hash-table-update!)
       (hash-table-set! ht key value)
     ) ;define
 
     (define (hash-table-update!/default ht key updater default)
+      (assert-hash-table-type ht hash-table-update!/default)
+      (when (not (procedure? updater))
+        (error 'type-error
+          hash-table-update!/default
+          "this parameter must be typed as procedure"
+        ) ;error
+      ) ;when
       (hash-table-set! ht key (updater (hash-table-ref/default ht key default)))
     ) ;define
 
@@ -142,6 +151,9 @@
     ) ;define
 
     (define (hash-table-find proc ht failure)
+      (when (not (procedure? proc))
+        (error 'type-error hash-table-find "this parameter must be typed as procedure")
+      ) ;when
       (assert-hash-table-type ht hash-table-find)
       (let ((keys (hash-table-keys ht)))
         (let loop
@@ -163,6 +175,9 @@
     ) ;define
 
     (define (hash-table-fold proc seed ht)
+      (when (not (procedure? proc))
+        (error 'type-error hash-table-fold "this parameter must be typed as procedure")
+      ) ;when
       (assert-hash-table-type ht hash-table-fold)
       (let ((result seed))
         (hash-table-for-each (lambda (k v) (set! result (proc k v result))) ht)

--- a/tests/liii/hash-table/hash-table-contains-p-test.scm
+++ b/tests/liii/hash-table/hash-table-contains-p-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii hash-table))
+(import (liii check) (liii error) (liii hash-table))
 
 
 (check-set-mode! 'report-failed)
@@ -46,6 +46,12 @@
 
 
 (check-false (hash-table-contains? (make-hash-table) 'missing))
+
+
+(check-catch 'type-error (hash-table-contains? "not-a-table" 'key))
+(check-catch 'type-error (hash-table-contains? 123 'key))
+(check-catch 'type-error (hash-table-contains? '((a . 1)) 'key))
+
 
 
 (check-report)

--- a/tests/liii/hash-table/hash-table-find-test.scm
+++ b/tests/liii/hash-table/hash-table-find-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii hash-table))
+(import (liii check) (liii error) (liii hash-table))
 
 
 (check-set-mode! 'report-failed)
@@ -61,6 +61,11 @@
 (let ((empty-ht (make-hash-table)))
   (check (hash-table-find (lambda (k v) #t) empty-ht 'empty) => 'empty)
 ) ;let
+
+
+(check-catch 'type-error (hash-table-find "not-a-procedure" (make-hash-table) 'not-found))
+(check-catch 'type-error (hash-table-find (lambda (k v) #t) "not-a-table" 'not-found))
+
 
 
 (check-report)

--- a/tests/liii/hash-table/hash-table-fold-test.scm
+++ b/tests/liii/hash-table/hash-table-fold-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii hash-table))
+(import (liii check) (liii error) (liii hash-table))
 
 
 (check-set-mode! 'report-failed)
@@ -46,6 +46,11 @@
 
 
 (check (hash-table-fold (lambda (k v acc) (+ acc v)) 10 (hash-table)) => 10)
+
+
+(check-catch 'type-error (hash-table-fold "not-a-procedure" 0 (make-hash-table)))
+(check-catch 'type-error (hash-table-fold (lambda (k v acc) acc) 0 "not-a-table"))
+
 
 
 (check-report)

--- a/tests/liii/hash-table/hash-table-ref-slash-default-test.scm
+++ b/tests/liii/hash-table/hash-table-ref-slash-default-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii hash-table))
+(import (liii check) (liii error) (liii hash-table))
 
 
 (check-set-mode! 'report-failed)
@@ -51,6 +51,11 @@
 (let ((ht (make-hash-table)) (fn (lambda (x) (+ x 1))))
   (check ((hash-table-ref/default ht 'not-exist fn) 5) => 6)
 ) ;let
+
+
+(check-catch 'type-error (hash-table-ref/default "not-a-table" 'key 'default))
+(check-catch 'type-error (hash-table-ref/default 123 'key 'default))
+(check-catch 'type-error (hash-table-ref/default '((a . 1)) 'key 'default))
 
 
 

--- a/tests/liii/hash-table/hash-table-update-bang-slash-default-test.scm
+++ b/tests/liii/hash-table/hash-table-update-bang-slash-default-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii hash-table))
+(import (liii check) (liii error) (liii hash-table))
 
 
 (check-set-mode! 'report-failed)
@@ -55,6 +55,12 @@
   (hash-table-update!/default ht 'key2 (lambda (x) #f) 5)
   (check (hash-table-ref ht 'key2) => #f)
 ) ;let
+
+
+(check-catch 'type-error (hash-table-update!/default "not-a-table" 'key (lambda (x) x) 0))
+(check-catch 'type-error (hash-table-update!/default (make-hash-table) 'key "not-a-procedure" 0))
+(check-catch 'type-error (hash-table-update!/default (make-hash-table) 'key 123 0))
+
 
 
 (check-report)

--- a/tests/liii/hash-table/hash-table-update-bang-test.scm
+++ b/tests/liii/hash-table/hash-table-update-bang-test.scm
@@ -50,6 +50,8 @@
 
 
 (check-catch 'type-error (hash-table-update! "not-a-table" 'key 'value))
+(check-catch 'type-error (hash-table-update! 123 'key 'value))
+(check-catch 'type-error (hash-table-update! '((a . 1)) 'key 'value))
 
 
 (check-report)


### PR DESCRIPTION
## What
1. 在 `goldfish/srfi/srfi-125.scm` 中为 `hash-table-ref/default`、`hash-table-update!`、`hash-table-update!/default`、`hash-table-find`、`hash-table-fold` 等函数补充前置参数类型检查。
2. 规范化错误处理，非哈希表及非过程参数在入口统一拦截并抛出 `type-error`。
3. 在相关单元测试中补充对应的 `check-catch 'type-error` 回归用例。

## Why
此前这些函数未进行充分的前置类型检查，传入非哈希表会穿透到底层抛出非规范的 `wrong-type-arg`；对空表调用 `find` 或 `fold` 传入非过程对象会静默返回默认值，违背了类型安全规范。

## How
使用统一的 `assert-hash-table-type` 和 `procedure?` 校验，未通过时统一抛出标准的 `type-error`。