### PR TITLE
[0165] 消除 s7_internal.h 中 inline 函数未定义编译警告

### DIFF
--- a/devel/0165.md
+++ b/devel/0165.md
@@ -1,0 +1,27 @@
+# [0165] 消除 s7_internal.h 中 inline 函数未定义编译警告
+
+## 任务相关的代码文件
+- src/s7_internal.h
+- devel/0165.md
+
+## 如何测试
+```bash
+xmake b -r goldfish
+bin/gf fmt --check
+bin/gf test --all
+```
+
+## 2026-09-08 消除 s7_internal.h 中 inline 函数未定义编译警告
+
+### What
+消除构建 `goldfish` 时由 `s7_scheme_read.c`、`s7_scheme_write.c`、`s7_continuation.c`、`s7_scheme_let.c` 等编译单元产生的 4 处 `inline function declared but never defined` 编译警告：
+1. `liberate`
+2. `mallocate_block`
+3. `make_simple_vector`
+4. `inline_make_let_with_slot`
+
+### Why
+在 `src/s7_internal.h` 中，上述 4 个跨编译单元调用的函数被声明为 `extern inline ...`，而其实际函数定义位于 `src/s7.c` 中。根据 C99 标准，若函数声明为 `inline`，则在同一个编译单元（translation unit）内必须提供其内联定义。对于仅在 `s7.c` 中提供定义、供其他 `.c` 文件外部引用的函数，声明为 `inline` 会导致 GCC 触发 `warning: inline function '...' declared but never defined`。
+
+### How
+在 `src/s7_internal.h` 中移除这 4 个函数原型声明中的 `inline` 关键字，使其成为规范的外部函数原型声明。

--- a/src/s7_internal.h
+++ b/src/s7_internal.h
@@ -1681,7 +1681,7 @@ no_return void error_nr(s7_scheme *sc, s7_pointer type, s7_pointer info);
   }
 
 /* inline_make_let_with_slot (decl) */
-extern inline s7_pointer inline_make_let_with_slot(s7_scheme *sc, s7_pointer old_let, s7_pointer symbol, s7_pointer value);
+s7_pointer inline_make_let_with_slot(s7_scheme *sc, s7_pointer old_let, s7_pointer symbol, s7_pointer value);
 
 /* is_any_closure (macro) */
 #define is_any_closure(P)              t_any_closure_p[type(P)]
@@ -1755,10 +1755,10 @@ s7_pointer lookup(s7_scheme *sc, const s7_pointer symbol);
 s7_pointer make_let(s7_scheme *sc, s7_pointer old_let);
 
 /* make_simple_vector (decl) */
-extern inline s7_pointer make_simple_vector(s7_scheme *sc, s7_int len);
+s7_pointer make_simple_vector(s7_scheme *sc, s7_int len);
 
 /* mallocate_block (decl) */
-extern inline block_t *mallocate_block(s7_scheme *sc);
+block_t *mallocate_block(s7_scheme *sc);
 
 /* mark_stack_1 (decl) */
 void mark_stack_1(s7_pointer stack, s7_int top);
@@ -2040,7 +2040,7 @@ extern bool t_vector_p[NUM_TYPES];
 void memclr(void *s, size_t n);
 
 /* function decls for s7_scheme_write.c (object->port), definitions live in s7.c */
-extern inline void liberate(s7_scheme *sc, block_t *blk);
+void liberate(s7_scheme *sc, block_t *blk);
 char *pos_int_to_str(s7_scheme *sc, s7_int num, s7_int *len, char endc);
 char *pos_int_to_str_direct(s7_scheme *sc, s7_int num);
 char *pos_int_to_str_direct_1(s7_scheme *sc, s7_int num);


### PR DESCRIPTION
## What
消除构建 `goldfish` 时由 `s7_scheme_read.c`、`s7_scheme_write.c`、`s7_continuation.c`、`s7_scheme_let.c` 等编译单元产生的 4 处 `inline function declared but never defined` 编译警告：
1. `liberate`
2. `mallocate_block`
3. `make_simple_vector`
4. `inline_make_let_with_slot`

## Why
在 `src/s7_internal.h` 中，上述 4 个跨编译单元调用的函数被声明为 `extern inline ...`，而其实际函数定义位于 `src/s7.c` 中。根据 C99 标准，若函数声明为 `inline`，则在同一个编译单元内必须提供其内联定义。声明为 `inline` 会导致 GCC 触发 `warning: inline function '...' declared but never defined`。

## How
在 `src/s7_internal.h` 中移除这 4 个函数原型声明中的 `inline` 关键字，使其成为规范的外部函数原型声明。