### PR TITLE
[0166] 修复 subprocess 模块命令参数环形结构导致的死循环崩溃

### DIFF
--- a/devel/0166.md
+++ b/devel/0166.md
@@ -13,6 +13,15 @@ bin/gf fmt
 bin/gf tests/liii/subprocess/run-values-test.scm
 ```
 
+## 2026-09-08 修复 subprocess 模块命令参数环形结构导致的死循环崩溃
+
+### What
+1. 在 `src/liii_subprocess.cpp` 的 `f_subprocess_run_values` 入口处增加 `s7_is_proper_list (sc, cmd_arg)` 检查：若 `cmd_arg` 既不是 string 也不是 proper list，则抛出 `type-error`。
+2. 在 `goldfish/liii/subprocess.scm` 的 `%command->exec-spec` 中增加 `(not (proper-list? command))` 检查，在 Scheme 层前置拦截非 proper 列表并抛出 `type-error`。
+
+### Why
+原实现中遍历 `cmd_arg` 列表使用 `while (s7_is_pair (p))`，若传入环形列表，`argv.push_back` 会无限循环追加元素，最终导致系统内存耗尽（OOM）崩溃。
+
 ## 2026-09-08 增加 subprocess 命令参数环形结构测试用例
 
 ### What

--- a/devel/0166.md
+++ b/devel/0166.md
@@ -1,0 +1,19 @@
+# [0166] 修复 (liii subprocess) 命令参数为环形列表时无限循环导致 OOM 崩溃
+
+## 任务相关的代码文件
+- src/liii_subprocess.cpp
+- goldfish/liii/subprocess.scm
+- tests/liii/subprocess/run-values-test.scm
+- devel/0166.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt
+bin/gf tests/liii/subprocess/run-values-test.scm
+```
+
+## 2026-09-08 增加 subprocess 命令参数环形结构测试用例
+
+### What
+1. 在 `tests/liii/subprocess/run-values-test.scm` 中增加针对环形 `command` 参数的回归测试用例，覆盖公开接口 `run-values` 与底层胶水接口 `g_subprocess-run-values`。

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -118,6 +118,13 @@
 
     (define (%command->exec-spec command)
       (cond ((string? command) command)
+            ((not (proper-list? command))
+             (type-error (format #f
+                           "Command must be a proper list or a string, got: ~a"
+                           (object->string command)
+                         ) ;format
+             ) ;type-error
+            ) ;
             ((and (pair? command) (symbol? (car command)))
              (%resolve-symbol-command (car command) (cdr command))
             ) ;

--- a/src/liii_subprocess.cpp
+++ b/src/liii_subprocess.cpp
@@ -46,6 +46,10 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
   s7_pointer cmd_arg= s7_car (args);
   args              = s7_cdr (args);
 
+  if (!s7_is_string (cmd_arg) && !s7_is_proper_list (sc, cmd_arg)) {
+    return subprocess_type_error (sc, "g_subprocess-run-values: command must be a proper list or a string", cmd_arg);
+  }
+
   const char* cwd= nullptr;
   if (s7_is_pair (args) && s7_is_string (s7_car (args))) {
     cwd = s7_string (s7_car (args));

--- a/tests/liii/subprocess/run-values-test.scm
+++ b/tests/liii/subprocess/run-values-test.scm
@@ -265,4 +265,11 @@
   (check-catch 'type-error (g_subprocess-run-values '("true") #f cyclic-env))
 ) ;let
 
+;; 环形 command 防御回归测试
+(let ((cyclic-cmd (list 'true "arg")))
+  (set-cdr! (cdr cyclic-cmd) cyclic-cmd)
+  (check-catch 'type-error (run-values cyclic-cmd))
+  (check-catch 'type-error (g_subprocess-run-values cyclic-cmd))
+) ;let
+
 (check-report)


### PR DESCRIPTION
## 描述
修复 `(liii subprocess)` 命令参数为环形列表时无限循环导致 OOM 崩溃的问题。

### 提交包含：
1. `[0166] 增加 subprocess 命令参数环形结构测试用例`
2. `[0166] 修复 subprocess 模块命令参数环形结构导致的死循环崩溃`

### 改动内容：
1. 在 `src/liii_subprocess.cpp` 的 `f_subprocess_run_values` 入口处增加 `s7_is_proper_list (sc, cmd_arg)` 检查：若 `cmd_arg` 既不是 string 也不是 proper list，则抛出 `type-error`。
2. 在 `goldfish/liii/subprocess.scm` 的 `%command->exec-spec` 中增加 `(not (proper-list? command))` 检查，在 Scheme 层前置拦截非 proper 列表并抛出 `type-error`。
3. 在 `tests/liii/subprocess/run-values-test.scm` 中增加针对环形 command 参数的回归测试用例。