### PR TITLE
[0167] 修复 set! *load-path* 遇环形列表死循环问题

### DIFF
--- a/devel/0167.md
+++ b/devel/0167.md
@@ -1,0 +1,28 @@
+# [0167] 修复 set! *load-path* 遇环形列表死循环问题
+
+## 任务相关的代码文件
+- src/s7_module.c
+- tests/scheme/boot-test.scm
+- devel/0167.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt
+bin/gf tests/scheme/boot-test.scm
+```
+
+预期：构建成功，代码格式化检查通过，全部测试用例通过。
+
+## 2026-09-08 修复 set! *load-path* 遇环形列表死循环问题
+
+### What
+1. 在 `src/s7_module.c` 的 `g_load_path_set` 中增加 `s7_list_length(sc, new_load_path) <= 0` 前置校验，拦截环形列表及非规范点对列表。
+2. 将 `g_load_path_set` 中的异常符号统一规范化为 `type-error`。
+3. 在 `tests/scheme/boot-test.scm` 中添加针对 `set! *load-path*` 异常入参（非列表、点对列表、环形列表、非字符串元素）的拦截测试用例。
+
+### Why
+当通过 `set! *load-path*` 传入环形列表时，原代码在检查各元素是否为字符串的 `for` 循环中仅以 `s7_is_pair` 作为终止条件，导致循环永不终止，引发 CPU 100% 死循环挂起。同时原代码抛出的 `wrong-type-arg` 不符合 Goldfish 优先采用 `type-error` 的错误体系规范。
+
+### How
+参考同文件中 `g_features_set` 与 `g_libraries_set` 的做法，在遍历列表元素之前，使用 `s7_list_length` 对列表进行长度及环检测：对于非空且长度 `<= 0`（即环形列表返回 0，点对列表返回负数）的情况直接抛出 `type-error`，并在整个 setter 中统一使用 `type-error`。

--- a/src/s7_module.c
+++ b/src/s7_module.c
@@ -12,18 +12,23 @@
 /* -------- *load-path* setter -------- */
 s7_pointer g_load_path_set(s7_scheme *sc, s7_pointer args)
 {
-  s7_pointer strs;
-  if (s7_is_null(sc, s7_cadr(args))) return s7_cadr(args);
-  if (!s7_is_pair(s7_cadr(args)))
-    return s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
-                    s7_list(sc, 2, s7_make_string(sc, "can't set *load-path* to ~S"), s7_cadr(args)));
-  for (strs = s7_cadr(args); s7_is_pair(strs); strs = s7_cdr(strs))
+  const s7_pointer new_load_path = s7_cadr(args);
+  if (s7_is_null(sc, new_load_path)) return new_load_path;
+  if (!s7_is_pair(new_load_path))
+    return s7_error(sc, s7_make_symbol(sc, "type-error"),
+                    s7_list(sc, 2, s7_make_string(sc, "can't set *load-path* to ~S"), new_load_path));
+  if (s7_list_length(sc, new_load_path) <= 0)
+    return s7_error(sc, s7_make_symbol(sc, "type-error"),
+                    s7_list(sc, 2,
+                            s7_make_string(sc, "can't set *load-path* to an improper or circular list ~S"),
+                            new_load_path));
+  for (s7_pointer strs = new_load_path; s7_is_pair(strs); strs = s7_cdr(strs))
     if (!s7_is_string(s7_car(strs)))
-      return s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
+      return s7_error(sc, s7_make_symbol(sc, "type-error"),
                       s7_list(sc, 3,
                               s7_make_string(sc, "can't set *load-path* to ~S, ~S is not a string"),
-                              s7_cadr(args), s7_car(strs)));
-  return s7_cadr(args);
+                              new_load_path, s7_car(strs)));
+  return new_load_path;
 }
 
 /* -------- *features* setter -------- */

--- a/tests/scheme/boot-test.scm
+++ b/tests/scheme/boot-test.scm
@@ -395,4 +395,16 @@
   ) ;define-library
 ) ;check-catch
 
+;; 验证 set! *load-path* 对非法值的防御
+(check-catch 'type-error (set! *load-path* 123))
+(check-catch 'type-error (set! *load-path* "not-a-list"))
+(check-catch 'type-error (set! *load-path* (cons "a" "b")))
+(check-catch 'type-error
+  (let ((p (list "foo")))
+    (set-cdr! p p)
+    (set! *load-path* p)
+  ) ;let
+) ;check-catch
+(check-catch 'type-error (set! *load-path* (list 123)))
+
 (check-report "\n\nCheck report of boot-test.scm => ")


### PR DESCRIPTION
# [0167] 修复 set! *load-path* 遇环形列表死循环问题

## 任务相关的代码文件
- src/s7_module.c
- tests/scheme/boot-test.scm
- devel/0167.md

## 如何测试
```bash
xmake b goldfish
bin/gf fmt
bin/gf tests/scheme/boot-test.scm
```

预期：构建成功，代码格式化检查通过，全部测试用例通过。

## 2026-09-08 修复 set! *load-path* 遇环形列表死循环问题

### What
1. 在 `src/s7_module.c` 的 `g_load_path_set` 中增加 `s7_list_length(sc, new_load_path) <= 0` 前置校验，拦截环形列表及非规范点对列表。
2. 将 `g_load_path_set` 中的异常符号统一规范化为 `type-error`。
3. 在 `tests/scheme/boot-test.scm` 中添加针对 `set! *load-path*` 异常入参（非列表、点对列表、环形列表、非字符串元素）的拦截测试用例。

### Why
当通过 `set! *load-path*` 传入环形列表时，原代码在检查各元素是否为字符串的 `for` 循环中仅以 `s7_is_pair` 作为终止条件，导致循环永不终止，引发 CPU 100% 死循环挂起。同时原代码抛出的 `wrong-type-arg` 不符合 Goldfish 优先采用 `type-error` 的错误体系规范。

### How
参考同文件中 `g_features_set` 与 `g_libraries_set` 的做法，在遍历列表元素之前，使用 `s7_list_length` 对列表进行长度及环检测：对于非空且长度 `<= 0`（即环形列表返回 0，点对列表返回负数）的情况直接抛出 `type-error`，并在整个 setter 中统一使用 `type-error`。