### PR TITLE
[0169] 统一 path-mkdir 测试用例为冒号前缀关键字参数风格

### DIFF
--- a/devel/0169.md
+++ b/devel/0169.md
@@ -1,0 +1,23 @@
+# [0169] 统一 path-mkdir 测试用例为冒号前缀关键字参数风格
+
+## 任务相关的代码文件
+- tests/liii/path/path-mkdir-test.scm
+- devel/0169.md
+
+## 如何测试
+```bash
+bin/gf fmt
+bin/gf tests/liii/path/path-mkdir-test.scm
+```
+
+预期：代码格式化检查通过，全部测试用例通过。
+
+## 2026-09-08 统一 path-mkdir 测试用例为冒号前缀关键字参数风格
+
+### What
+1. 将 `tests/liii/path/path-mkdir-test.scm` 中的关键字参数调用从后缀形式（`parents: #t`, `exist-ok: #t`）统一修改为前缀风格（`:parents #t`, `:exist-ok #t`）。
+2. 在注释和语法说明中同步更新为 `:parents` 与 `:exist-ok` 前缀形式。
+3. 补充 `:parents #t` 与 `:exist-ok #t` 组合调用时的测试用例。
+
+### Why
+Goldfish Scheme 推荐统一使用 `:key` 的前缀关键字参数风格，保持代码与测试风格规范一致。

--- a/tests/liii/path/path-mkdir-test.scm
+++ b/tests/liii/path/path-mkdir-test.scm
@@ -7,7 +7,7 @@
 ;;
 ;; 语法
 ;; ----
-;; (path-mkdir path-value parents: bool exist-ok: bool) 或 (path-mkdir p)
+;; (path-mkdir path-value :parents bool :exist-ok bool) 或 (path-mkdir p)
 ;;
 ;; 返回值
 ;; ------
@@ -39,20 +39,22 @@
   (path-mkdir base)
   (check-true (path-dir? base))
 
-  ;; 2. exist-ok=#f 默认,已存在时报错
+  ;; exist-ok=#f 默认,已存在时报错
   (check (guard (ex (else 'caught)) (path-mkdir base)) => 'caught)
-  ;; exist-ok=#t 已存在不报错
-  (check (path-mkdir base exist-ok: #t) => #t)
+  ;; :exist-ok #t 已存在不报错
+  (check (path-mkdir base :exist-ok #t) => #t)
 
-  ;; 3. parents=#t 递归创建多级
+  ;; 3. :parents #t 递归创建多级
   (let ((deep (path-join base "a" "b" "c")))
-    (path-mkdir deep parents: #t)
+    (path-mkdir deep :parents #t)
     (check-true (path-dir? deep))
-    ;; parents:#t 但叶子已存在且 exist-ok:#f(默认)时报错(对齐 pathlib)
-    (check-catch 'file-exists-error (path-mkdir deep parents: #t))
+    ;; :parents #t 但叶子已存在且 :exist-ok #f(默认)时报错(对齐 pathlib)
+    (check-catch 'file-exists-error (path-mkdir deep :parents #t))
+    ;; :parents #t 且 :exist-ok #t 时不报错
+    (check (path-mkdir deep :parents #t :exist-ok #t) => #t)
   ) ;let
 
-  ;; 4. parents=#f 缺中间目录时报错
+  ;; 4. :parents #f 缺中间目录时报错
   (let ((missing (path-join base "nope" "deep")))
     (check (guard (ex (else 'caught)) (path-mkdir missing)) => 'caught)
   ) ;let


### PR DESCRIPTION
## Summary

统一 `path-mkdir` 测试用例及文档说明中的关键字参数风格，优先使用 `:key` 前缀风格（`:parents #t`, `:exist-ok #t`）。

## Changes
- 将 `tests/liii/path/path-mkdir-test.scm` 中关键字参数从后缀形式（`parents:`, `exist-ok:`）改为前缀风格（`:parents`, `:exist-ok`）。
- 补充 `:parents #t` 与 `:exist-ok #t` 组合调用的测试断言。
- 增加开发说明文档 `devel/0169.md`。

## Test
```bash
bin/gf fmt
bin/gf tests/liii/path/path-mkdir-test.scm
```
所有测试通过（7 checks passed）。