### PR TITLE
[0173] 修复 g_vector_append 方法分派路径丢失 GC 保护的问题

### DIFF
--- a/devel/0173.md
+++ b/devel/0173.md
@@ -1,0 +1,25 @@
+# [0173] 修复 g_vector_append 方法分派路径丢失 GC 保护的问题
+
+## 任务相关的代码文件
+- src/s7_liii_vector.c
+- tests/liii/vector/vector-append-test.scm
+- devel/0173.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt tests/liii/vector/vector-append-test.scm
+bin/gf tests/liii/vector/vector-append-test.scm
+```
+
+## 2026-09-09 为 vector-append openlet 方法分派与 GC 场景补充测试用例
+
+### What
+1. 在 `tests/liii/vector/vector-append-test.scm` 中补充 `vector-append` 的 openlet 方法分派测试：
+   - openlet 处于首参数（`i == 0`）时的分派校验；
+   - openlet 处于非首参数（`i > 0`）时的前置拼接分派校验；
+   - openlet 处于中间参数位置（同时包含前置向量与后置向量）时的分派校验；
+   - 增加 GC 压力回归测试：在循环内对 `vector-append` 传入 openlet 并在其分派方法内部调用 `(gc)`。
+
+### Why
+此前 `vector-append` 缺乏对 openlet 对象的方法分派及 GC 回收场景测试用例。在 commit 0168 迁出 `g_vector_append` 后，方法分派路径未通过栈 anchor 机制保护相关局部对象，存在 GC 隐患。先补充测试用例以覆盖该路径。

--- a/devel/0173.md
+++ b/devel/0173.md
@@ -12,6 +12,22 @@ bin/gf fmt tests/liii/vector/vector-append-test.scm
 bin/gf tests/liii/vector/vector-append-test.scm
 ```
 
+## 2026-09-09 修复 g_vector_append 方法分派路径丢失 GC 保护的问题
+
+### What
+1. 在 `src/s7_liii_vector.c` 的 `g_vector_append` 中，为非首参 openlet 方法分派路径添加栈 GC 保护：
+   - 使用 `s7_cons(sc, s7_cons(sc, func, p), s7_nil(sc))` 建立 `anchor`，并通过 `s7_gc_protect_via_stack` 入栈保护；
+   - 构造及反转 `front` 参数列表时，挂载在 `anchor` 的 cdr 上，使中间列表对 GC 始终可见；
+   - 递归调用 `g_vector_append(sc, front)` 得到中间向量 `vec` 后，挂载到 `anchor` 的 cdr 上保护；
+   - 构造参数 `s7_cons(sc, vec, p)` 并挂载到 `anchor` 后，调用 `s7_apply_function(sc, func, call_args)`；
+   - 调用返回后通过 `s7_gc_unprotect_via_stack(sc, anchor)` 释放栈保护。
+
+### Why
+在 commit 0168 从 `s7.c` 迁出 `g_vector_append` 时，原实现中用 `sc->temp7` 锚定前半部分参数列表并在递归和方法调用全程保持保护的设计被遗漏。新代码中 `front` 构造、递归 `g_vector_append` 及 `s7_apply_function` 调用期间无 anchor，若参数来自求值器复用单元或在此期间触发 GC，`func`、`p`、`front` 和 `vec` 存在被提前回收损坏的隐患。
+
+### How
+仿照同文件 `g_vector_filter`（约 :984）的模式，建立包含 `(func . p)` 以及动态挂载 `front`/`vec`/`call_args` 的 `anchor` pair，并在进入方法分派时通过 `s7_gc_protect_via_stack` 挂入 GC 栈，全程保护直到方法调用返回后再取消保护。
+
 ## 2026-09-09 为 vector-append openlet 方法分派与 GC 场景补充测试用例
 
 ### What

--- a/src/s7_liii_vector.c
+++ b/src/s7_liii_vector.c
@@ -508,28 +508,17 @@ s7_pointer g_vector_append(s7_scheme *sc, s7_pointer args)
                 return(s7_apply_function(sc, func, args));
 
               /* args may live in evaluator-recycled cells, so keep func and p in our own
-               * anchor pair, with front/vec as the anchor's cdr; everything stays
+               * anchor pair, with the working list as the anchor's cdr; everything stays
                * GC-reachable across recursive append and method apply */
               s7_pointer anchor = s7_cons(sc, s7_cons(sc, func, p), s7_nil(sc));
               s7_gc_protect_via_stack(sc, anchor);
-
-              s7_pointer front = s7_nil(sc);
               s7_pointer arglist = args;
               for (int32_t k = 0; k < i; k++, arglist = s7_cdr(arglist))
-                {
-                  front = s7_cons(sc, s7_car(arglist), front);
-                  s7_set_cdr(anchor, front);
-                }
-              front = s7_reverse(sc, front);
-              s7_set_cdr(anchor, front);
-
-              s7_pointer vec = g_vector_append(sc, front);
-              s7_set_cdr(anchor, vec);
-
-              s7_pointer call_args = s7_cons(sc, vec, p);
-              s7_set_cdr(anchor, call_args);
-
-              s7_pointer result = s7_apply_function(sc, func, call_args);
+                s7_set_cdr(anchor, s7_cons(sc, s7_car(arglist), s7_cdr(anchor)));
+              s7_set_cdr(anchor, s7_reverse(sc, s7_cdr(anchor)));
+              s7_set_cdr(anchor, g_vector_append(sc, s7_cdr(anchor)));
+              s7_set_cdr(anchor, s7_cons(sc, s7_cdr(anchor), p));
+              s7_pointer result = s7_apply_function(sc, func, s7_cdr(anchor));
               s7_gc_unprotect_via_stack(sc, anchor);
               return(result);
             }

--- a/src/s7_liii_vector.c
+++ b/src/s7_liii_vector.c
@@ -506,13 +506,32 @@ s7_pointer g_vector_append(s7_scheme *sc, s7_pointer args)
             {
               if (i == 0)
                 return(s7_apply_function(sc, func, args));
+
+              /* args may live in evaluator-recycled cells, so keep func and p in our own
+               * anchor pair, with front/vec as the anchor's cdr; everything stays
+               * GC-reachable across recursive append and method apply */
+              s7_pointer anchor = s7_cons(sc, s7_cons(sc, func, p), s7_nil(sc));
+              s7_gc_protect_via_stack(sc, anchor);
+
               s7_pointer front = s7_nil(sc);
               s7_pointer arglist = args;
               for (int32_t k = 0; k < i; k++, arglist = s7_cdr(arglist))
-                front = s7_cons(sc, s7_car(arglist), front);
+                {
+                  front = s7_cons(sc, s7_car(arglist), front);
+                  s7_set_cdr(anchor, front);
+                }
               front = s7_reverse(sc, front);
+              s7_set_cdr(anchor, front);
+
               s7_pointer vec = g_vector_append(sc, front);
-              return(s7_apply_function(sc, func, s7_cons(sc, vec, p)));
+              s7_set_cdr(anchor, vec);
+
+              s7_pointer call_args = s7_cons(sc, vec, p);
+              s7_set_cdr(anchor, call_args);
+
+              s7_pointer result = s7_apply_function(sc, func, call_args);
+              s7_gc_unprotect_via_stack(sc, anchor);
+              return(result);
             }
           return(s7_type_error(sc, "vector-append", i + 1, vect, "a vector"));
         }

--- a/tests/liii/vector/vector-append-test.scm
+++ b/tests/liii/vector/vector-append-test.scm
@@ -72,4 +72,42 @@
 (check-catch 'type-error (vector-append #(1 2) 3 #(4 5)))
 
 
+;; openlet 方法分派测试与 GC 压力测试
+(let ((o (openlet (inlet 'vector-append (lambda (self . rest) (apply vector-append #(0) rest)))
+         ) ;openlet
+      ) ;o
+     ) ;
+  (check (vector-append o #(1 2)) => #(0 1 2))
+) ;let
+
+(let ((o (openlet (inlet 'vector-append (lambda (vec self) (vector-append vec #(99)))))
+      ) ;o
+     ) ;
+  (check (vector-append #(1 2) o) => #(1 2 99))
+) ;let
+
+(let ((o (openlet (inlet 'vector-append
+                    (lambda (vec self . rest) (apply vector-append vec #(99) rest))
+                  ) ;inlet
+         ) ;openlet
+      ) ;o
+     ) ;
+  (check (vector-append #(1) #(2) o #(3) #(4)) => #(1 2 99 3 4))
+) ;let
+
+;; GC 压力回归测试：openlet vector-append 方法内触发 GC
+(let ((v #(1 2)))
+  (do ((i 0 (+ i 1)))
+    ((= i 100))
+    (let ((o (openlet (inlet 'vector-append (lambda (vec self) (gc) (vector-append vec #(3))))
+             ) ;openlet
+          ) ;o
+         ) ;
+      (check (vector-append v o) => #(1 2 3))
+    ) ;let
+  ) ;do
+) ;let
+
+
+
 (check-report)

--- a/tests/liii/vector/vector-append-test.scm
+++ b/tests/liii/vector/vector-append-test.scm
@@ -72,33 +72,39 @@
 (check-catch 'type-error (vector-append #(1 2) 3 #(4 5)))
 
 
-;; openlet 方法分派测试与 GC 压力测试
-(let ((o (openlet (inlet 'vector-append (lambda (self . rest) (apply vector-append #(0) rest)))
-         ) ;openlet
-      ) ;o
-     ) ;
-  (check (vector-append o #(1 2)) => #(0 1 2))
-) ;let
+;; openlet 方法分派测试：openlet 位于首参 / 非首参 / 中间位置
+(check (vector-append (openlet (inlet 'vector-append (lambda (self . rest) (apply vector-append #(0) rest)))
+                      ) ;openlet
+         #(1 2)
+       ) ;vector-append
+  =>
+  #(0 1 2)
+) ;check
 
-(let ((o (openlet (inlet 'vector-append (lambda (vec self) (vector-append vec #(99)))))
-      ) ;o
-     ) ;
-  (check (vector-append #(1 2) o) => #(1 2 99))
-) ;let
+(check (vector-append #(1 2)
+         (openlet (inlet 'vector-append (lambda (vec self) (vector-append vec #(99)))))
+       ) ;vector-append
+  =>
+  #(1 2 99)
+) ;check
 
-(let ((o (openlet (inlet 'vector-append
+(check (vector-append #(1)
+         #(2)
+         (openlet (inlet 'vector-append
                     (lambda (vec self . rest) (apply vector-append vec #(99) rest))
                   ) ;inlet
          ) ;openlet
-      ) ;o
-     ) ;
-  (check (vector-append #(1) #(2) o #(3) #(4)) => #(1 2 99 3 4))
-) ;let
+         #(3)
+         #(4)
+       ) ;vector-append
+  =>
+  #(1 2 99 3 4)
+) ;check
 
 ;; GC 压力回归测试：openlet vector-append 方法内触发 GC
 (let ((v #(1 2)))
   (do ((i 0 (+ i 1)))
-    ((= i 100))
+    ((= i 5))
     (let ((o (openlet (inlet 'vector-append (lambda (vec self) (gc) (vector-append vec #(3))))
              ) ;openlet
           ) ;o
@@ -107,7 +113,6 @@
     ) ;let
   ) ;do
 ) ;let
-
 
 
 (check-report)


### PR DESCRIPTION
## 描述
修复 0168 引入的 `g_vector_append` 方法分派路径丢失 GC 保护的问题：
1. 为 `vector-append` 补充 openlet 方法分派场景及 GC 回归测试用例。
2. 参照 `g_vector_filter`，在 `g_vector_append` 中使用 `s7_gc_protect_via_stack` 建立栈 anchor，保护 `(func . p)` 以及构造中的 `front`、`vec` 和 `call_args`，确保在递归 append 与方法分派期间对象始终处于 GC 保护下。

## 相关文件
- `src/s7_liii_vector.c`
- `tests/liii/vector/vector-append-test.scm`
- `devel/0173.md`