### PR TITLE
[0174] 规范化 reverse! 类型错误为 type-error

### DIFF
--- a/devel/0174.md
+++ b/devel/0174.md
@@ -1,0 +1,29 @@
+# [0174] 规范化 reverse! 类型错误为 type-error
+
+## 任务相关的代码文件
+- src/s7.c
+- tests/liii/base/reverse-bang-test.scm
+- devel/0174.md
+
+## 如何测试
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化代码
+bin/gf fmt
+
+# 3. 运行测试
+bin/gf tests/liii/base/reverse-bang-test.scm
+```
+
+## 2026-09-10 复现 reverse! 对非序列和非标准列表抛 wrong-type-arg 问题
+
+### What
+在 `tests/liii/base/reverse-bang-test.scm` 中增加并规范化异常测试用例：
+1. 将原有的 `(check-catch 'wrong-type-arg (reverse! '(1 2 . 3)))` 和 `(check-catch 'wrong-type-arg (reverse! 123))` 修改为预期规范的 `type-error`。
+2. 扩充针对参数数量异常（`wrong-number-of-args`）以及非序列类型参数（布尔值 `#t`、符号 `'a`）的错误捕获断言。
+3. 运行测试复现失败：由于底层当前抛出的是 `wrong-type-arg` 而不是 `type-error`，测试断言失败。
+
+### Why
+遵循测试驱动开发（TDD）原则，在修复前先通过单元测试明确期望的正确行为并复现既有缺陷。

--- a/devel/0174.md
+++ b/devel/0174.md
@@ -17,6 +17,16 @@ bin/gf fmt
 bin/gf tests/liii/base/reverse-bang-test.scm
 ```
 
+## 2026-09-10 修复 reverse! 对非序列及非标准列表参数抛错为 type-error
+
+### What
+1. 在 `src/s7.c` 中，将 `reverse_pair_in_place` 中的 `wrong_type_error_nr` 替换为 `type_error_nr`。
+2. 在 `src/s7.c` 中，将 `reverse_in_place_via_method` 中的 `sole_arg_wrong_type_error_nr` 替换为 `sole_arg_type_error_nr`，并将未匹配方法时的回退调用由 `method_or_bust_p` 切换为已支持 `type-error` 的 `vector_method_or_bust_p`。
+3. 运行 `bin/gf tests/liii/base/reverse-bang-test.scm` 及全量测试，验证异常捕获均匹配 `type-error` 且全部通过。
+
+### Why
+根据 Goldfish Scheme 规范，类型错误应统一使用 `type-error` 代替历史遗留的 `wrong-type-arg`。
+
 ## 2026-09-10 复现 reverse! 对非序列和非标准列表抛 wrong-type-arg 问题
 
 ### What

--- a/src/s7.c
+++ b/src/s7.c
@@ -31972,8 +31972,8 @@ static s7_pointer reverse_pair_in_place(s7_scheme *sc, s7_pointer obj, s7_pointe
     if (is_null(lst))
       {
 	if (!s7_is_proper_list(sc, obj))
-	  wrong_type_error_nr(sc, sc->reverseb_symbol, 1, car(args), wrap_string(sc, "a proper list", 13));
-	wrong_type_error_nr(sc, sc->reverseb_symbol, 1, car(args), wrap_string(sc, "a mutable proper list", 21));
+	  type_error_nr(sc, sc->reverseb_symbol, 1, car(args), wrap_string(sc, "a proper list", 13));
+	type_error_nr(sc, sc->reverseb_symbol, 1, car(args), wrap_string(sc, "a mutable proper list", 21));
       }
     return(lst);
   }
@@ -31993,12 +31993,12 @@ static s7_pointer reverse_in_place_via_method(s7_scheme *sc, s7_pointer obj)
     {
       if (is_simple_sequence(obj))
 	immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->reverseb_symbol, obj));
-      sole_arg_wrong_type_error_nr(sc, sc->reverseb_symbol, obj, a_sequence_string);
+      sole_arg_type_error_nr(sc, sc->reverseb_symbol, obj, a_sequence_string);
     }
   if ((is_simple_sequence(obj)) &&
       (!has_active_methods(sc, obj)))
-    sole_arg_wrong_type_error_nr(sc, sc->reverseb_symbol, obj, wrap_string(sc, "a vector, string, or list", 25));
-  return(method_or_bust_p(sc, obj, sc->reverseb_symbol, a_sequence_string));
+    sole_arg_type_error_nr(sc, sc->reverseb_symbol, obj, wrap_string(sc, "a vector, string, or list", 25));
+  return(vector_method_or_bust_p(sc, obj, sc->reverseb_symbol, a_sequence_string));
 }
 
 static s7_pointer g_reverse_in_place(s7_scheme *sc, s7_pointer args)

--- a/tests/liii/base/reverse-bang-test.scm
+++ b/tests/liii/base/reverse-bang-test.scm
@@ -70,7 +70,11 @@
 ) ;let
 
 ;; 异常情况测试
-(check-catch 'wrong-type-arg (reverse! '(1 2 . 3)))
-(check-catch 'wrong-type-arg (reverse! 123))
+(check-catch 'wrong-number-of-args (reverse!))
+(check-catch 'wrong-number-of-args (reverse! '() '()))
+(check-catch 'type-error (reverse! '(1 2 . 3)))
+(check-catch 'type-error (reverse! 123))
+(check-catch 'type-error (reverse! #t))
+(check-catch 'type-error (reverse! 'a))
 
 (check-report)


### PR DESCRIPTION
## 描述
根据 Goldfish Scheme 规范，将 `reverse!` 对非序列参数及非标准列表参数的报错类型从历史遗留的 `wrong-type-arg` 统一为 `type-error`：
1. **测试驱动复现**：在 `tests/liii/base/reverse-bang-test.scm` 中将原有的 `(check-catch 'wrong-type-arg ...)` 修改为 `type-error`，并补充针对参数个数与非序列类型（如 `#t`、`'a`）的异常用例。
2. **底层修复**：在 `src/s7.c` 的 `reverse_pair_in_place` 与 `reverse_in_place_via_method` 中使用 `type_error_nr`、`sole_arg_type_error_nr` 与 `vector_method_or_bust_p`，统一抛出规范的 `type-error`。

## 相关文件
- `src/s7.c`
- `tests/liii/base/reverse-bang-test.scm`
- `devel/0174.md`