### PR TITLE
[0160] 清理 goldfish.hpp 中未使用的 static 函数 goldfish_print_prefixed_scheme_error_message

### DIFF
--- a/devel/0160.md
+++ b/devel/0160.md
@@ -37,6 +37,14 @@ for f in $(find tools/ -name "*-test.scm"); do bin/gf test "$f"; done
 
 预期：构建成功，格式化检查通过，相关测试全部通过。
 
+## 2026-09-10 清理 goldfish.hpp 中未使用的死代码
+
+### What
+删除 `src/goldfish.hpp` 中未使用的静态函数 `goldfish_print_prefixed_scheme_error_message`。
+
+### Why
+该函数原用于 C++ 层处理工具运行和子命令导入时的错误输出，在 0160 将工具执行逻辑迁移至 Scheme 模块 `(liii gfproject)` 后，所有调用点均已被删除，成为死代码并可能触发 `-Wunused-function` 警告。
+
 ## 2026-09-08 移除 3rdparty/nlohmann_json/ 并将 gfproject 逻辑迁移至 Scheme
 
 ### What

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -1184,19 +1184,6 @@ goldfish_print_scheme_error_message (s7_scheme* sc, const char* errmsg) {
 }
 
 static void
-goldfish_print_prefixed_scheme_error_message (s7_scheme* sc, const string& prefix, const char* errmsg) {
-  if ((errmsg) && (*errmsg)) {
-    string rendered;
-    goldfish_render_scheme_error_message (sc, errmsg, rendered);
-    cerr << prefix;
-    if ((!prefix.empty ()) && (prefix.back () != '\n')) {
-      cerr << '\n';
-    }
-    cerr << rendered;
-  }
-}
-
-static void
 goldfish_eval_code (s7_scheme* sc, string code) {
   string     wrapped_code= "(begin " + code + " )";
   s7_pointer x           = s7_eval_c_string (sc, wrapped_code.c_str ());


### PR DESCRIPTION
详见 devel/0160.md