### PR TITLE
[0175] 规范化 take 负数参数错误类型为 out-of-range

### DIFF
--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -986,7 +986,7 @@ s7_pointer g_take(s7_scheme *sc, s7_pointer args)
     return list_type_error(sc, "take", k, "second argument must be an integer");
   s7_int n = s7_integer(k);
   if (n < 0)
-    return list_type_error(sc, "take", k, "second argument must be a non-negative integer");
+    return(s7_out_of_range_error(sc, "take", 2, k, "it is negative"));
   if (!s7_is_pair(lst) && !s7_is_null(sc, lst))
     return list_type_error(sc, "take", lst, "first argument must be a list");
   if (n == 0) return(s7_nil(sc));

--- a/tests/liii/list/take-test.scm
+++ b/tests/liii/list/take-test.scm
@@ -71,7 +71,7 @@
 (check (take (iota 10) 5) => '(0 1 2 3 4))
 
 
-(check-catch 'type-error (take '(1 2 3) -1))
+(check-catch 'out-of-range (take '(1 2 3) -1))
 (check-catch 'type-error (take "not a list" 2))
 (check-catch 'type-error (take '(1 2 3) "not a number"))
 


### PR DESCRIPTION
## Summary
- [0175] 复现 take 负数参数错误类型不是 out-of-range 问题
- [0175] 修复 take 负数参数错误类型为 out-of-range

## Details
- `take` 接收负数参数时原先抛出 `type-error`，与其他列表函数（`take-right`、`drop-right`、`drop`、`list-tail` 等统一抛 `out-of-range`）不一致。
- 修复 `src/s7_liii_list.c` 中 `g_take`，当 `n < 0` 时抛出 `out-of-range`。
- 更新 `tests/liii/list/take-test.scm` 测试用例。
