### PR TITLE
[0170] 规范化 subvector 维度不匹配错误类型为 value-error

### DIFF
--- a/devel/0170.md
+++ b/devel/0170.md
@@ -23,6 +23,16 @@ bin/gf test tests/
 
 预期：构建成功，代码格式化无误，全部 1484 个单元测试通过，0 failed。
 
+## 2026-09-10 规范化 subvector 维度不匹配错误类型为 value-error
+
+### What
+1. 在 `s7_scheme` 中添加 `value_error_symbol`（`'value-error`），并在系统初始化时完成绑定。
+2. 将 `src/s7.c` 中 `subvector` 维度乘积与切片区间长度不匹配时抛出的历史遗留 `wrong-type-arg` 规范化为 `value-error`。
+3. 在 `tests/liii/vector/subvector-test.scm` 增加维度乘积不匹配抛出 `value-error` 以及维度元素非法抛出 `type-error` 的测试覆盖。
+
+### Why
+在多维向量/切片操作中，维度参数本身类型正确（均为整型维度列表），但各维度乘积与切片区间大小不匹配时，属于值不合法而非类型错误，语义上与 Python/NumPy 中的 `ValueError` 及 Goldfish 整体规范一致，应抛出 `value-error`。
+
 ## 2026-09-09 统一 vector 相关接口错误类型为 type-error
 
 ### What

--- a/devel/0170.md
+++ b/devel/0170.md
@@ -23,6 +23,16 @@ bin/gf test tests/
 
 预期：构建成功，代码格式化无误，全部 1484 个单元测试通过，0 failed。
 
+## 2026-09-10 补充 subvector 文档并从 (liii vector) 导出
+
+### What
+1. 在 `goldfish/liii/vector.scm` 的 `(export ...)` 列表中导出 `subvector`、`subvector?`、`subvector-position` 与 `subvector-vector`。
+2. 在 `tests/liii/vector/subvector-test.scm` 增加符合 `gf doc` 规范的完整结构化文档注释（涵盖描述、详细参数作用、返回值、共享存储注意项及错误类型说明）。
+3. 补充默认参数及配套函数测试用例，并执行 `bin/gf doc --build-json` 重建全局函数文档索引。
+
+### Why
+`subvector` 此前未在 `(liii vector)` 模块中显式导出，且测试文件缺少标准 golddoc 文档头部，导致 `bin/gf doc subvector` 无法检索并展示文档。
+
 ## 2026-09-10 规范化 subvector 维度不匹配错误类型为 value-error
 
 ### What

--- a/goldfish/liii/vector.scm
+++ b/goldfish/liii/vector.scm
@@ -11,7 +11,7 @@
     int-vector? make-int-vector int-vector-ref int-vector-set! complex-vector
     complex-vector? make-complex-vector complex-vector-ref complex-vector-set!
     float-vector float-vector? make-float-vector float-vector-ref
-    float-vector-set!
+    float-vector-set! subvector subvector? subvector-position subvector-vector
   ) ;export
   (begin
 

--- a/src/s7.c
+++ b/src/s7.c
@@ -1388,7 +1388,7 @@ struct s7_scheme {
              read_error_symbol, readable_keyword, rest_keyword, set_symbol, string_read_error_symbol, symbol_table_symbol,
              syntax_error_symbol, trace_in_symbol, type_symbol, unbound_variable_symbol, unless_symbol,
              unquote_symbol, value_symbol, when_symbol, with_baffle_symbol, with_let_symbol, write_keyword,
-             wrong_number_of_args_symbol, wrong_type_arg_symbol, type_error_symbol;
+             wrong_number_of_args_symbol, wrong_type_arg_symbol, type_error_symbol, value_error_symbol;
 
   /* signatures of sequences used as applicable objects: ("hi" 1) */
   s7_pointer  byte_vector_signature, c_object_signature, float_vector_signature, hash_table_signature, int_vector_signature,
@@ -23600,7 +23600,7 @@ s7_pointer s7i_subvector_1(s7_scheme *sc, s7_pointer args)
 	      if (new_len != new_end - offset)
 		{
 		  liberate(sc, vd); /* 14-Sep-23 */
-		  error_nr(sc, sc->wrong_type_arg_symbol,
+		  error_nr(sc, sc->value_error_symbol,
 			   set_elist_4(sc, wrap_string(sc, "subvector dimensional length, ~D, does not match the start and end positions: ~S to ~S~%", 88),
 				       wrap_integer(sc, new_len), start, end));
 		}
@@ -79558,6 +79558,7 @@ then returns each var to its original value."
   sc->unbound_variable_symbol =     make_symbol(sc, "unbound-variable", 16);
   sc->wrong_type_arg_symbol =       make_symbol(sc, "wrong-type-arg", 14);
   sc->type_error_symbol =            make_symbol(sc, "type-error", 10);
+  sc->value_error_symbol =           make_symbol(sc, "value-error", 11);
   sc->wrong_number_of_args_symbol = make_symbol(sc, "wrong-number-of-args", 20);
   sc->format_error_symbol =         make_symbol(sc, "format-error", 12);
   sc->autoload_error_symbol =       make_symbol(sc, "autoload-error", 14);

--- a/src/s7_internal.h
+++ b/src/s7_internal.h
@@ -1404,7 +1404,7 @@ struct s7_scheme {
              read_error_symbol, readable_keyword, rest_keyword, set_symbol, string_read_error_symbol, symbol_table_symbol,
              syntax_error_symbol, trace_in_symbol, type_symbol, unbound_variable_symbol, unless_symbol,
              unquote_symbol, value_symbol, when_symbol, with_baffle_symbol, with_let_symbol, write_keyword,
-             wrong_number_of_args_symbol, wrong_type_arg_symbol, type_error_symbol;
+             wrong_number_of_args_symbol, wrong_type_arg_symbol, type_error_symbol, value_error_symbol;
 
   /* signatures of sequences used as applicable objects: ("hi" 1) */
   s7_pointer  byte_vector_signature, c_object_signature, float_vector_signature, hash_table_signature, int_vector_signature,

--- a/tests/liii/vector/subvector-test.scm
+++ b/tests/liii/vector/subvector-test.scm
@@ -27,4 +27,13 @@
   (check-catch 'out-of-range (subvector v 2 1))
 ) ;let
 
+(let ((v #(1 2 3 4 5 6)))
+  (check-catch 'value-error (subvector v 0 6 '(2 2)))
+  (check-catch 'value-error (subvector v 0 6 '(3 3)))
+  (check-catch 'value-error (subvector v 1 5 '(3 2)))
+  (check-catch 'type-error (subvector v 0 6 '((1 2) (3 4))))
+  (check-catch 'type-error (subvector v 0 6 '(7 1)))
+  (check-catch 'type-error (subvector v 0 6 '(-1 1)))
+) ;let
+
 (check-report)

--- a/tests/liii/vector/subvector-test.scm
+++ b/tests/liii/vector/subvector-test.scm
@@ -2,10 +2,50 @@
 
 (check-set-mode! 'report-failed)
 
-;; subvector 基本功能
+;; subvector
+;; 创建与原向量共享数据存储的子向量（切片）。
+;;
+;; 语法
+;; ----
+;; (subvector orig)
+;; (subvector orig start)
+;; (subvector orig start end)
+;; (subvector orig start end dimensions)
+;;
+;; 参数
+;; ----
+;; orig       : vector?
+;;              要截取子向量的目标向量（支持通用 vector 及 int-vector、float-vector 等特化向量）。子向量将与该目标向量共享底层内存。
+;; start      : exact-nonnegative-integer?，可选，默认值为 0
+;;              切片在原向量中的起始索引（从 0 开始计数，包含该位置）。
+;; end        : exact-nonnegative-integer?，可选，默认值为原向量的元素总数
+;;              切片在原向量中的结束索引（不包含该位置，与 start 构成半开区间 [start, end)）。切片包含的元素总数为 end - start。
+;; dimensions : (list-of exact-positive-integer?)，可选
+;;              指定新子向量的形状与维度大小（例如 '(3 2) 表示 3 行 2 列）。若省略则返回长度为 end - start 的一维向量；若指定，列表中所有维度的乘积必须严格等于切片元素总数 end - start。
+;;
+;; 返回值
+;; ----
+;; vector
+;; 与原向量在指定区间共享底层内存的子向量（满足 subvector? 与 vector?）。
+;;
+;; 注意
+;; ----
+;; 1. 共享内存特性：修改子向量的元素会同步影响原向量，反之亦然。
+;; 2. 配套操作：可用 subvector? 判断是否为子向量，用 subvector-vector 获取原向量，用 subvector-position 获取在原向量中的偏移量。
+;;
+;; 错误处理
+;; ----
+;; type-error: orig 不是向量、start/end 不是整数或 dimensions 不是整数列表时抛出
+;; out-of-range: start/end 为负数、超出原向量范围或 start > end 时抛出
+;; value-error: dimensions 各维度乘积与切片区间长度不一致时抛出
+
+;; 基本功能与默认参数
 (let ((v #(1 2 3 4 5 6)))
   (check (subvector? (subvector v 0 3)) => #t)
   (check (subvector-position (subvector v 2 4)) => 2)
+  (check (subvector-vector (subvector v 2 4)) => v)
+  (check (vector->list (subvector v)) => '(1 2 3 4 5 6))
+  (check (vector->list (subvector v 2)) => '(3 4 5 6))
   (check (vector->list (subvector v 1 4)) => '(2 3 4))
   (check (vector-dimensions (subvector v 0 6 '(3 2))) => '(3 2))
   (check (vector-ref (subvector v 0 6 '(3 2)) 1 1) => 4)


### PR DESCRIPTION
### What
1. 在 `s7_scheme` 中添加 `value_error_symbol`（`'value-error`），并在初始化时绑定；
2. 将 `src/s7.c` 中 `subvector` 维度乘积与切片区间长度不匹配分支中的错误类型从 `wrong-type-arg` 规范化为 `value-error`；
3. 在 `tests/liii/vector/subvector-test.scm` 补充针对维度乘积不匹配抛出 `value-error` 及维度元素非法抛出 `type-error` 的测试覆盖；
4. 更新 `devel/0170.md`。

### Why
在多维向量/切片操作中，维度参数本身类型正确（均为整型维度列表），但各维度乘积与切片区间大小不匹配时，属于值不合法而非类型错误，语义上与 Python/NumPy 中的 `ValueError` 及 Goldfish 整体规范一致，应规范化为 `value-error`。