### PR TITLE
[0175] 将 Scheme 代码中的 wrong-type-arg 规范化为 type-error

### DIFF
--- a/devel/0175.md
+++ b/devel/0175.md
@@ -1,0 +1,50 @@
+# [0175] 规范化 scheme 代码中 wrong-type-arg 为 type-error
+
+## 任务相关的代码文件
+- `goldfish/scheme/base.scm`
+- `goldfish/srfi/srfi-13.scm`
+- `goldfish/srfi/srfi-27.scm`
+- `goldfish/srfi/srfi-117.scm`
+- `goldfish/srfi/srfi-215.scm`
+- `goldfish/liii/logging.scm`
+- `goldfish/liii/case.scm`
+- `goldfish/liii/packrat.scm`
+- `tests/srfi/srfi-117-test.scm`
+- 相关测试文件
+
+## 如何测试
+```bash
+# 运行相关单元测试
+bin/gf tests/srfi/srfi-117-test.scm
+bin/gf tests/srfi/srfi-13/string-prefix-p-test.scm
+bin/gf tests/srfi/srfi-13/string-suffix-p-test.scm
+bin/gf tests/scheme/base/floor-slash-test.scm
+bin/gf tests/scheme/base/floor-quotient-test.scm
+bin/gf tests/scheme/base/truncate-slash-test.scm
+bin/gf tests/liii/logging-test.scm
+bin/gf tests/srfi/srfi-215-test.scm
+bin/gf tests/liii/case-test.scm
+bin/gf tests/liii/random/random-source-make-reals-test.scm
+```
+
+## 2026/04/18 为 wrong-type-arg 替换为 type-error 添加与更新单元测试
+
+### What
+1. 新增 `tests/srfi/srfi-117-test.scm`，测试 SRFI-117 队列基本操作与空队列时捕获 `type-error`
+2. 在 `tests/liii/logging-test.scm` 中补充 `send-log` 严重级别与消息类型错误的 `type-error` 捕获测试
+3. 在 `tests/liii/case-test.scm` 中增加模式匹配非过程等错误抛出 `type-error` 的测试
+4. 在 `tests/liii/string/string-pad-test.scm`、`string-pad-right-test.scm`、`string-tokenize-test.scm` 中增加对多余非 list 参数捕获 `type-error` 的测试
+5. 更新已有测试文件中的 `check-catch 'wrong-type-arg` 为 `check-catch 'type-error'`：
+   - `tests/scheme/base/floor-slash-test.scm`
+   - `tests/scheme/base/floor-quotient-test.scm`
+   - `tests/scheme/base/truncate-slash-test.scm`
+   - `tests/srfi/srfi-13/string-prefix-p-test.scm`
+   - `tests/srfi/srfi-13/string-suffix-p-test.scm`
+   - `tests/liii/string/string-drop-test.scm`
+   - `tests/liii/string/string-any-test.scm`
+   - `tests/liii/string/string-every-test.scm`
+   - `tests/srfi/srfi-215-test.scm`
+   - `tests/liii/random/*`（共 7 个测试文件）
+
+### Why
+按照 Goldfish Scheme 的错误规范，类型错误应统一使用 `type-error` 符号而非 `wrong-type-arg`。采用 TDD 流程，先添加与更新单元测试（Red），再修改实现（Green）。

--- a/devel/0175.md
+++ b/devel/0175.md
@@ -27,6 +27,19 @@ bin/gf tests/liii/case-test.scm
 bin/gf tests/liii/random/random-source-make-reals-test.scm
 ```
 
+## 2026/04/18 将 Scheme 代码中的 wrong-type-arg 替换为 type-error
+
+### What
+1. `goldfish/scheme/base.scm`：将 `floor/` 与 `truncate/` 参数校验错误类型由 `wrong-type-arg` 改为 `type-error`
+2. `goldfish/srfi/srfi-13.scm`：将 `%make-criterion`、`string-drop`、`string-drop-right`、`string-pad`、`string-pad-right`、`string-prefix?`、`string-suffix?`、`string-tokenize` 中的 `wrong-type-arg` 改为 `type-error`
+3. `goldfish/srfi/srfi-27.scm`：将随机源状态与参数校验错误类型统一由 `wrong-type-arg` 改为 `type-error`
+4. `goldfish/srfi/srfi-117.scm`：将空队列操作 `list-queue-front`、`list-queue-back`、`list-queue-remove-front!`、`list-queue-remove-back!` 错误类型由 `wrong-type-arg` 改为 `type-error`
+5. `goldfish/srfi/srfi-215.scm` 与 `goldfish/liii/logging.scm`：将 `send-log` 的 `severity` 与 `message` 参数校验错误类型由 `wrong-type-arg` 改为 `type-error`，并在校验前增加 `(number? severity)` 防御
+6. `goldfish/liii/case.scm`：将模式匹配中的非过程及非法描述符等错误类型由 `wrong-type-arg` 改为 `type-error`
+7. `goldfish/liii/packrat.scm`：修复宏内部 `(else (type-error? 'wrong-type-arg))` 笔误，改为 `(type-error "invalid pattern in packrat-lambda" pattern)`
+8. 保留 `goldfish/liii/error.scm` 中 `type-error?` 谓词对原生 S7 抛出的 `wrong-type-arg` 的兼容
+9. 同步更新由于底层变更而受影响的测试用例（`tests/liii/queue/` 与 `tests/liii/string/`）为 `type-error`
+
 ## 2026/04/18 为 wrong-type-arg 替换为 type-error 添加与更新单元测试
 
 ### What

--- a/goldfish/liii/case.scm
+++ b/goldfish/liii/case.scm
@@ -72,7 +72,7 @@
                                                         (error 'unbound-variable "function ~S is undefined\n" func)
                                                       ) ;if
                                                       (if (not (procedure? func-val))
-                                                        (error 'wrong-type-arg "~S is not a function\n" func)
+                                                        (error 'type-error "~S is not a function\n" func)
                                                       ) ;if
                                                       func-val
                                                     ) ;let
@@ -172,7 +172,7 @@
                             (define (undefined->function undef e)
                               (let* ((str1 (object->string undef)) (str1-end (- (length str1) 1)))
                                 (if (not (char=? (str1 str1-end) #\>))
-                                  (error 'wrong-type-arg "pattern descriptor does not end in '>': ~S\n" str1)
+                                  (error 'type-error "pattern descriptor does not end in '>': ~S\n" str1)
                                 ) ;if
                                 (let ((str (substring str1 2 str1-end)))
                                   (if (= (length str) 0)
@@ -198,7 +198,7 @@
                                                                    (if (undefined? func-val)
                                                                      (error 'unbound-variable "function ~S is undefined\n" func)
                                                                      (if (not (procedure? func-val))
-                                                                       (error 'wrong-type-arg "~S is not a function\n" func)
+                                                                       (error 'type-error "~S is not a function\n" func)
                                                                        (lambda (x) (set! (labels label) x) (func-val x))
                                                                      ) ;if
                                                                    ) ;if
@@ -228,9 +228,7 @@
                                   (if (undefined? func)
                                     (error 'unbound-variable "function ~S is undefined\n" pat-item)
                                   ) ;if
-                                  (if (not (procedure? func))
-                                    (error 'wrong-type-arg "~S is not a function\n" func)
-                                  ) ;if
+                                  (if (not (procedure? func)) (error 'type-error "~S is not a function\n" func))
                                   (func sel-item)
                                 ) ;let
                               ) ;and
@@ -241,7 +239,7 @@
                                   (let ((func-ok #t))
                                     (when (or (pair? pat) (vector? pat))
                                       (if (pair? (cyclic-sequences pat))
-                                        (error 'wrong-type-arg "case* pattern is cyclic: ~S~%" pat)
+                                        (error 'type-error "case* pattern is cyclic: ~S~%" pat)
                                       ) ;if
                                       (let ((pos (if (pair? pat)
                                                    (ellipsis-pair-position 0 pat)

--- a/goldfish/liii/logging.scm
+++ b/goldfish/liii/logging.scm
@@ -131,8 +131,8 @@
     ) ;define
 
     (define (send-log severity message . plist)
-      (unless (and (exact? severity) (integer? severity) (<= 0 severity 7))
-        (error 'wrong-type-arg
+      (unless (and (number? severity) (exact? severity) (integer? severity) (<= 0 severity 7))
+        (error 'type-error
           "send-log: expected a severity from 0 to 7"
           severity
           message
@@ -140,7 +140,7 @@
         ) ;error
       ) ;unless
       (unless (string? message)
-        (error 'wrong-type-arg
+        (error 'type-error
           "send-log: expected message to be a string"
           severity
           message

--- a/goldfish/liii/packrat.scm
+++ b/goldfish/liii/packrat.scm
@@ -444,7 +444,7 @@
                                  ) ;
                                  ((() #<>) `(lambda (results)
                                               (make-result ,body results)))
-                                 (else (type-error? 'wrong-type-arg))
+                                 (else (type-error "invalid pattern in packrat-lambda" pattern))
                                 ) ;case*
                               ) ;lambda
                ) ;parse-pattern

--- a/goldfish/scheme/base.scm
+++ b/goldfish/scheme/base.scm
@@ -317,7 +317,7 @@
 
     (define (floor/ x y)
       (when (or (not (real? x)) (not (real? y)))
-        (error 'wrong-type-arg "floor/: parameters must be real numbers")
+        (error 'type-error "floor/: parameters must be real numbers")
       ) ;when
       (when (zero? y)
         (error 'division-by-zero "floor/: division by zero")
@@ -339,7 +339,7 @@
 
     (define (truncate/ x y)
       (when (or (not (real? x)) (not (real? y)))
-        (error 'wrong-type-arg "truncate/: parameters must be real numbers")
+        (error 'type-error "truncate/: parameters must be real numbers")
       ) ;when
       (when (zero? y)
         (error 'division-by-zero "truncate/: division by zero")

--- a/goldfish/srfi/srfi-117.scm
+++ b/goldfish/srfi/srfi-117.scm
@@ -86,14 +86,14 @@
 
     (define (list-queue-front list-queue)
       (if (list-queue-empty? list-queue)
-        (error 'wrong-type-arg "list-queue-front: empty list-queue")
+        (error 'type-error "list-queue-front: empty list-queue")
         (car (get-first list-queue))
       ) ;if
     ) ;define
 
     (define (list-queue-back list-queue)
       (if (list-queue-empty? list-queue)
-        (error 'wrong-type-arg "list-queue-back: empty list-queue")
+        (error 'type-error "list-queue-back: empty list-queue")
         (car (get-last list-queue))
       ) ;if
     ) ;define
@@ -127,7 +127,7 @@
 
     (define (list-queue-remove-front! list-queue)
       (if (list-queue-empty? list-queue)
-        (error 'wrong-type-arg "list-queue-remove-front!: empty list-queue")
+        (error 'type-error "list-queue-remove-front!: empty list-queue")
         (let* ((old-first (get-first list-queue))
                (elem (car old-first))
                (new-first (cdr old-first))
@@ -141,7 +141,7 @@
 
     (define (list-queue-remove-back! list-queue)
       (if (list-queue-empty? list-queue)
-        (error 'wrong-type-arg "list-queue-remove-back!: empty list-queue")
+        (error 'type-error "list-queue-remove-back!: empty list-queue")
         (let* ((old-last (get-last list-queue))
                (elem (car old-last))
                (new-last (penult-pair (get-first list-queue)))

--- a/goldfish/srfi/srfi-13.scm
+++ b/goldfish/srfi/srfi-13.scm
@@ -36,7 +36,7 @@
     (define (%make-criterion char/pred?)
       (cond ((char? char/pred?) (lambda (x) (char=? x char/pred?)))
             ((procedure? char/pred?) char/pred?)
-            (else (error 'wrong-type-arg "%make-criterion"))
+            (else (error 'type-error "%make-criterion"))
       ) ;cond
     ) ;define
 
@@ -96,10 +96,10 @@
     (define string-drop
       (lambda (str k)
         (unless (string? str)
-          (error 'wrong-type-arg "str is not string?" str)
+          (error 'type-error "str is not string?" str)
         ) ;unless
         (unless (integer? k)
-          (error 'wrong-type-arg "k is not integer?" k)
+          (error 'type-error "k is not integer?" k)
         ) ;unless
         (when (< k 0)
           (error 'out-of-range "k must be non-negative" k)
@@ -113,10 +113,10 @@
     (define string-drop-right
       (lambda (str k)
         (unless (string? str)
-          (error 'wrong-type-arg "str is not string?" str)
+          (error 'type-error "str is not string?" str)
         ) ;unless
         (unless (integer? k)
-          (error 'wrong-type-arg "k is not integer?" k)
+          (error 'type-error "k is not integer?" k)
         ) ;unless
         (when (< k 0)
           (error 'out-of-range "k must be non-negative" k)
@@ -146,7 +146,7 @@
                (car char+start+end)
              ) ;string-pad-sub
             ) ;
-            (else (error 'wrong-type-arg "string-pad"))
+            (else (error 'type-error "string-pad"))
       ) ;cond
     ) ;define
 
@@ -166,7 +166,7 @@
                (car char+start+end)
              ) ;string-pad-right-sub
             ) ;
-            (else (error 'wrong-type-arg "string-pad"))
+            (else (error 'type-error "string-pad-right"))
       ) ;cond
     ) ;define
 
@@ -268,18 +268,18 @@
 
     ;; string-prefix?/string-suffix? 复用 C 实现的 g_string-starts?/g_string-ends?
     ;; （见 src/liii_string.cpp），避免旧实现的 substring 临时分配；
-    ;; 注意参数顺序相反，且错误契约为 wrong-type-arg（区别于 liii 的 type-error）
+    ;; 注意参数顺序相反
     (define (string-prefix? prefix str)
       (if (and (string? prefix) (string? str))
         (g_string-starts? str prefix)
-        (error 'wrong-type-arg "string-prefix?: expected string arguments")
+        (error 'type-error "string-prefix?: expected string arguments")
       ) ;if
     ) ;define
 
     (define (string-suffix? suffix str)
       (if (and (string? suffix) (string? str))
         (g_string-ends? str suffix)
-        (error 'wrong-type-arg "string-suffix?: expected string arguments")
+        (error 'type-error "string-suffix?: expected string arguments")
       ) ;if
     ) ;define
 
@@ -496,7 +496,7 @@
                (car char+start+end)
              ) ;string-tokenize-sub
             ) ;
-            (else (error 'wrong-type-arg "string-tokenize"))
+            (else (error 'type-error "string-tokenize"))
       ) ;cond
     ) ;define
   ) ;begin

--- a/goldfish/srfi/srfi-215.scm
+++ b/goldfish/srfi/srfi-215.scm
@@ -80,8 +80,8 @@
 
     ;; send-log: 发送日志消息
     (define (send-log severity message . plist)
-      (unless (and (exact? severity) (integer? severity) (<= 0 severity 7))
-        (error 'wrong-type-arg
+      (unless (and (number? severity) (exact? severity) (integer? severity) (<= 0 severity 7))
+        (error 'type-error
           "send-log: expected a severity from 0 to 7"
           severity
           message
@@ -89,7 +89,7 @@
         ) ;error
       ) ;unless
       (unless (string? message)
-        (error 'wrong-type-arg
+        (error 'type-error
           "send-log: expected message to be a string"
           severity
           message

--- a/goldfish/srfi/srfi-27.scm
+++ b/goldfish/srfi/srfi-27.scm
@@ -96,7 +96,7 @@
                       (eq? (car new-state) 'random-source-state)
                       (= (length new-state) 3)
                     ) ;and
-              (error 'wrong-type-arg "invalid random source state" new-state)
+              (error 'type-error "invalid random source state" new-state)
             ) ;unless
             (let ((seed (cadr new-state)) (carry (caddr new-state)))
               (set! state (random-state seed carry))
@@ -116,16 +116,10 @@
           ;; pseudo-randomize!: use i, j indices
           (lambda (i j)
             (unless (and (integer? i) (exact? i) (>= i 0))
-              (error 'wrong-type-arg
-                "pseudo-randomize! i must be a non-negative exact integer"
-                i
-              ) ;error
+              (error 'type-error "pseudo-randomize! i must be a non-negative exact integer" i)
             ) ;unless
             (unless (and (integer? j) (exact? j) (>= j 0))
-              (error 'wrong-type-arg
-                "pseudo-randomize! j must be a non-negative exact integer"
-                j
-              ) ;error
+              (error 'type-error "pseudo-randomize! j must be a non-negative exact integer" j)
             ) ;unless
             ;; Create a deterministic state based on i and j
             ;; Using a simple hash of i and j to create seed and carry
@@ -139,7 +133,7 @@
           (lambda ()
             (lambda (n)
               (unless (and (integer? n) (exact? n) (positive? n))
-                (error 'wrong-type-arg "random-integer: n must be a positive exact integer" n)
+                (error 'type-error "random-integer: n must be a positive exact integer" n)
               ) ;unless
               ;; s7's random returns [0, n), we need [0, n-1] which is the same
               (random n state)
@@ -152,7 +146,7 @@
                 (begin
                   (set! unit (car args))
                   (unless (and (real? unit) (< 0 unit 1))
-                    (error 'wrong-type-arg
+                    (error 'type-error
                       "random-source-make-reals: unit must be a real in (0,1)"
                       unit
                     ) ;error
@@ -193,31 +187,28 @@
 
     (define (random-source-state-ref s)
       (unless (random-source? s)
-        (error 'wrong-type-arg "random-source-state-ref: expected random-source" s)
+        (error 'type-error "random-source-state-ref: expected random-source" s)
       ) ;unless
       ((random-source-state-ref-proc s))
     ) ;define
 
     (define (random-source-state-set! s new-state)
       (unless (random-source? s)
-        (error 'wrong-type-arg "random-source-state-set!: expected random-source" s)
+        (error 'type-error "random-source-state-set!: expected random-source" s)
       ) ;unless
       ((random-source-state-set-proc s) new-state)
     ) ;define
 
     (define (random-source-randomize! s)
       (unless (random-source? s)
-        (error 'wrong-type-arg "random-source-randomize!: expected random-source" s)
+        (error 'type-error "random-source-randomize!: expected random-source" s)
       ) ;unless
       ((random-source-randomize-proc s))
     ) ;define
 
     (define (random-source-pseudo-randomize! s i j)
       (unless (random-source? s)
-        (error 'wrong-type-arg
-          "random-source-pseudo-randomize!: expected random-source"
-          s
-        ) ;error
+        (error 'type-error "random-source-pseudo-randomize!: expected random-source" s)
       ) ;unless
       ((random-source-pseudo-randomize-proc s) i j)
     ) ;define
@@ -228,14 +219,14 @@
 
     (define (random-source-make-integers s)
       (unless (random-source? s)
-        (error 'wrong-type-arg "random-source-make-integers: expected random-source" s)
+        (error 'type-error "random-source-make-integers: expected random-source" s)
       ) ;unless
       ((random-source-make-integers-proc s))
     ) ;define
 
     (define (random-source-make-reals s . unit)
       (unless (random-source? s)
-        (error 'wrong-type-arg "random-source-make-reals: expected random-source" s)
+        (error 'type-error "random-source-make-reals: expected random-source" s)
       ) ;unless
       (apply (random-source-make-reals-proc s) unit)
     ) ;define

--- a/tests/liii/case-test.scm
+++ b/tests/liii/case-test.scm
@@ -378,5 +378,8 @@
 (check (if-expr? '(if (> x 0) x (- x))) => '(if-expr (> x 0) x (- x)))
 (check (if-expr? '(if flag then)) => #f)
 
+;; 非法模式或非过程错误测试
+(let ((not-a-func 42))
+  (check-catch 'type-error (case* '(1) (((#<x:not-a-func>)) #t))))
 
 (check-report)

--- a/tests/liii/logging-test.scm
+++ b/tests/liii/logging-test.scm
@@ -111,4 +111,12 @@
 ;; 恢复默认回调
 (log-set-callback! (lambda (log-entry) (values)))
 
+;; send-log 参数类型错误测试
+(check-catch 'type-error (send-log -1 "bad"))
+(check-catch 'type-error (send-log 8 "bad"))
+(check-catch 'type-error (send-log 3.5 "bad"))
+(check-catch 'type-error (send-log 'invalid "bad"))
+(check-catch 'type-error (send-log INFO 123))
+(check-catch 'type-error (send-log INFO 'not-a-string))
+
 (check-report)

--- a/tests/liii/queue/list-queue-back-test.scm
+++ b/tests/liii/queue/list-queue-back-test.scm
@@ -39,7 +39,7 @@
 
 
 ;; 空队列报错
-(check-catch 'wrong-type-arg (list-queue-back (list-queue)))
+(check-catch 'type-error (list-queue-back (list-queue)))
 
 
 (check-report)

--- a/tests/liii/queue/list-queue-front-test.scm
+++ b/tests/liii/queue/list-queue-front-test.scm
@@ -37,7 +37,7 @@
 
 
 ;; 空队列报错
-(check-catch 'wrong-type-arg (list-queue-front (list-queue)))
+(check-catch 'type-error (list-queue-front (list-queue)))
 
 
 (check-report)

--- a/tests/liii/queue/list-queue-remove-back-test.scm
+++ b/tests/liii/queue/list-queue-remove-back-test.scm
@@ -36,7 +36,7 @@
 
 
 ;; 空队列报错
-(check-catch 'wrong-type-arg (list-queue-remove-back! (list-queue)))
+(check-catch 'type-error (list-queue-remove-back! (list-queue)))
 
 
 (check-report)

--- a/tests/liii/queue/list-queue-remove-front-test.scm
+++ b/tests/liii/queue/list-queue-remove-front-test.scm
@@ -36,7 +36,7 @@
 
 
 ;; 空队列报错
-(check-catch 'wrong-type-arg (list-queue-remove-front! (list-queue)))
+(check-catch 'type-error (list-queue-remove-front! (list-queue)))
 
 
 (check-report)

--- a/tests/liii/random/random-integer-test.scm
+++ b/tests/liii/random/random-integer-test.scm
@@ -28,7 +28,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; wrong-type-arg 当 n 不是正整数时抛出。
+;; type-error 当 n 不是正整数时抛出。
 
 
 (let ((r (random-integer 10)))
@@ -49,10 +49,10 @@
 ) ;let
 
 
-(check-catch 'wrong-type-arg (random-integer 0))
-(check-catch 'wrong-type-arg (random-integer -1))
-(check-catch 'wrong-type-arg (random-integer 3.14))
-(check-catch 'wrong-type-arg (random-integer 'not-a-number))
+(check-catch 'type-error (random-integer 0))
+(check-catch 'type-error (random-integer -1))
+(check-catch 'type-error (random-integer 3.14))
+(check-catch 'type-error (random-integer 'not-a-number))
 
 
 (check-report)

--- a/tests/liii/random/random-source-make-integers-test.scm
+++ b/tests/liii/random/random-source-make-integers-test.scm
@@ -29,7 +29,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; wrong-type-arg 当 s 不是随机源时抛出。
+;; type-error 当 s 不是随机源时抛出。
 
 
 (let* ((s (make-random-source)) (rand-int (random-source-make-integers s)))
@@ -55,7 +55,7 @@
 ) ;let*
 
 
-(check-catch 'wrong-type-arg (random-source-make-integers 'not-a-source))
+(check-catch 'type-error (random-source-make-integers 'not-a-source))
 
 
 (check-report)

--- a/tests/liii/random/random-source-make-reals-test.scm
+++ b/tests/liii/random/random-source-make-reals-test.scm
@@ -33,7 +33,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; wrong-type-arg 当 s 不是随机源或 unit 无效时抛出。
+;; type-error 当 s 不是随机源或 unit 无效时抛出。
 
 
 (let* ((s (make-random-source)) (rand-real (random-source-make-reals s)))
@@ -59,13 +59,13 @@
 ) ;let*
 
 
-(check-catch 'wrong-type-arg (random-source-make-reals 'not-a-source))
+(check-catch 'type-error (random-source-make-reals 'not-a-source))
 
 
 (let ((s (make-random-source)))
-  (check-catch 'wrong-type-arg (random-source-make-reals s 0))
-  (check-catch 'wrong-type-arg (random-source-make-reals s 1))
-  (check-catch 'wrong-type-arg (random-source-make-reals s -0.5))
+  (check-catch 'type-error (random-source-make-reals s 0))
+  (check-catch 'type-error (random-source-make-reals s 1))
+  (check-catch 'type-error (random-source-make-reals s -0.5))
 ) ;let
 
 

--- a/tests/liii/random/random-source-pseudo-randomize-test.scm
+++ b/tests/liii/random/random-source-pseudo-randomize-test.scm
@@ -55,16 +55,16 @@
 ) ;let
 
 
-(check-catch 'wrong-type-arg
+(check-catch 'type-error
   (random-source-pseudo-randomize! 'not-a-source 0 0)
 ) ;check-catch
 
 
 (let ((s (make-random-source)))
-  (check-catch 'wrong-type-arg (random-source-pseudo-randomize! s -1 0))
-  (check-catch 'wrong-type-arg (random-source-pseudo-randomize! s 0 -1))
-  (check-catch 'wrong-type-arg (random-source-pseudo-randomize! s 3.14 0))
-  (check-catch 'wrong-type-arg (random-source-pseudo-randomize! s 0 3.14))
+  (check-catch 'type-error (random-source-pseudo-randomize! s -1 0))
+  (check-catch 'type-error (random-source-pseudo-randomize! s 0 -1))
+  (check-catch 'type-error (random-source-pseudo-randomize! s 3.14 0))
+  (check-catch 'type-error (random-source-pseudo-randomize! s 0 3.14))
 ) ;let
 
 

--- a/tests/liii/random/random-source-randomize-test.scm
+++ b/tests/liii/random/random-source-randomize-test.scm
@@ -29,7 +29,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; wrong-type-arg 当 s 不是随机源时抛出。
+;; type-error 当 s 不是随机源时抛出。
 
 
 (let ((s (make-random-source)))
@@ -53,8 +53,8 @@
 ) ;let
 
 
-(check-catch 'wrong-type-arg (random-source-randomize! 'not-a-source))
-(check-catch 'wrong-type-arg (random-source-randomize! 123))
+(check-catch 'type-error (random-source-randomize! 'not-a-source))
+(check-catch 'type-error (random-source-randomize! 123))
 
 
 (check-report)

--- a/tests/liii/random/random-source-state-ref-test.scm
+++ b/tests/liii/random/random-source-state-ref-test.scm
@@ -28,7 +28,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; wrong-type-arg 当 s 不是随机源时抛出。
+;; type-error 当 s 不是随机源时抛出。
 
 
 (let ((s (make-random-source)))
@@ -52,9 +52,9 @@
 ) ;let
 
 
-(check-catch 'wrong-type-arg (random-source-state-ref 'not-a-source))
-(check-catch 'wrong-type-arg (random-source-state-ref 123))
-(check-catch 'wrong-type-arg (random-source-state-ref "string"))
+(check-catch 'type-error (random-source-state-ref 'not-a-source))
+(check-catch 'type-error (random-source-state-ref 123))
+(check-catch 'type-error (random-source-state-ref "string"))
 
 
 (check-report)

--- a/tests/liii/random/random-source-state-set-test.scm
+++ b/tests/liii/random/random-source-state-set-test.scm
@@ -26,7 +26,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; wrong-type-arg 当 s 不是随机源或 state 格式无效时抛出。
+;; type-error 当 s 不是随机源或 state 格式无效时抛出。
 
 
 (let ((s (make-random-source)))
@@ -43,17 +43,17 @@
 ) ;let
 
 
-(check-catch 'wrong-type-arg
+(check-catch 'type-error
   (random-source-state-set! 'not-a-source '(random-source-state 0 0))
 ) ;check-catch
 
 
 (let ((s (make-random-source)))
-  (check-catch 'wrong-type-arg (random-source-state-set! s 'invalid-state))
-  (check-catch 'wrong-type-arg
+  (check-catch 'type-error (random-source-state-set! s 'invalid-state))
+  (check-catch 'type-error
     (random-source-state-set! s '(not-the-right-tag 0 0))
   ) ;check-catch
-  (check-catch 'wrong-type-arg
+  (check-catch 'type-error
     (random-source-state-set! s '(random-source-state))
   ) ;check-catch
 ) ;let

--- a/tests/liii/string/string-any-test.scm
+++ b/tests/liii/string/string-any-test.scm
@@ -49,7 +49,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; wrong-type-arg 当char/pred?不是字符或谓词时
+;; type-error 当char/pred?不是字符或谓词时
 ;; out-of-range 当start/end超出字符串索引范围时
 ;; wrong-type-arg 当str不是字符串时
 ;;
@@ -85,7 +85,7 @@
 (check-false (string-any char-alphabetic? "" 0 0))
 
 ;; 错误处理
-(check-catch 'wrong-type-arg (string-any 123 "hello"))
+(check-catch 'type-error (string-any 123 "hello"))
 (check-catch 'wrong-type-arg (string-any char-alphabetic? 123))
 (check-catch 'out-of-range (string-any char-alphabetic? "hello" -1))
 (check-catch 'out-of-range (string-any char-alphabetic? "hello" 0 6))

--- a/tests/liii/string/string-count-test.scm
+++ b/tests/liii/string/string-count-test.scm
@@ -44,7 +44,7 @@
 ;; 错误处理
 ;; ----
 ;; type-error 当str不是字符串类型时
-;; wrong-type-arg 当char/pred?不是字符或谓词时
+;; type-error 当char/pred?不是字符或谓词时
 ;; out-of-range 当start/end超出字符串索引范围时
 
 ;; 基本功能测试 - 字符参数
@@ -145,9 +145,9 @@
 
 ;; 错误处理测试
 (check-catch 'type-error (string-count 123 #\a))
-(check-catch 'wrong-type-arg (string-count "hello" 123))
-(check-catch 'wrong-type-arg (string-count "hello" "a"))
-(check-catch 'wrong-type-arg (string-count "hello" '(a b c)))
+(check-catch 'type-error (string-count "hello" 123))
+(check-catch 'type-error (string-count "hello" "a"))
+(check-catch 'type-error (string-count "hello" '(a b c)))
 
 ;; 参数数量错误测试
 (check-catch 'wrong-number-of-args (string-count))

--- a/tests/liii/string/string-drop-test.scm
+++ b/tests/liii/string/string-drop-test.scm
@@ -35,7 +35,7 @@
 ;; 错误处理
 ;; ----
 ;; out-of-range 当k大于字符串长度或k为负数时
-;; wrong-type-arg 当str不是字符串类型或k不是整数类型时
+;; type-error 当str不是字符串类型或k不是整数类型时
 
 ;;
 ;; 相关实现
@@ -74,10 +74,10 @@
 (check-catch 'out-of-range (string-drop "MathAgape" 20))
 (check-catch 'out-of-range (string-drop "" 1))
 (check-catch 'out-of-range (string-drop "Hello" -1))
-(check-catch 'wrong-type-arg (string-drop 123 4))
-(check-catch 'wrong-type-arg (string-drop "MathAgape" "4"))
-(check-catch 'wrong-type-arg (string-drop "MathAgape" 4.5))
-(check-catch 'wrong-type-arg (string-drop "MathAgape" 'a))
+(check-catch 'type-error (string-drop 123 4))
+(check-catch 'type-error (string-drop "MathAgape" "4"))
+(check-catch 'type-error (string-drop "MathAgape" 4.5))
+(check-catch 'type-error (string-drop "MathAgape" 'a))
 
 (check (string-drop "MathAgape" 8) => "e")
 (check (string-drop "MathAgape" 9) => "")
@@ -121,7 +121,7 @@
 ;; 错误处理
 ;; ----
 ;; out-of-range 当k大于字符串长度或k为负数时
-;; wrong-type-arg 当str不是字符串类型或k不是整数类型时
+;; type-error 当str不是字符串类型或k不是整数类型时
 
 (check (string-drop-right "MathAgape" 4) => "MathA")
 (check (string-drop-right "MathAgape" 0) => "MathAgape")
@@ -153,10 +153,10 @@
 (check-catch 'out-of-range (string-drop-right "MathAgape" 20))
 (check-catch 'out-of-range (string-drop-right "" 1))
 (check-catch 'out-of-range (string-drop-right "Hello" -1))
-(check-catch 'wrong-type-arg (string-drop-right 123 4))
-(check-catch 'wrong-type-arg (string-drop-right "MathAgape" "4"))
-(check-catch 'wrong-type-arg (string-drop-right "MathAgape" 4.5))
-(check-catch 'wrong-type-arg (string-drop-right "MathAgape" 'a))
+(check-catch 'type-error (string-drop-right 123 4))
+(check-catch 'type-error (string-drop-right "MathAgape" "4"))
+(check-catch 'type-error (string-drop-right "MathAgape" 4.5))
+(check-catch 'type-error (string-drop-right "MathAgape" 'a))
 
 (check (string-drop-right "MathAgape" 5) => "Math")
 (check (string-drop-right "MathAgape" 9) => "")

--- a/tests/liii/string/string-every-test.scm
+++ b/tests/liii/string/string-every-test.scm
@@ -47,7 +47,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; wrong-type-arg 当char/pred?不是字符或谓词时
+;; type-error 当char/pred?不是字符或谓词时
 ;; out-of-range 当start/end超出字符串索引范围时
 ;; wrong-type-arg 当str不是字符串时
 ;;
@@ -83,8 +83,8 @@
 (check-true (string-every char-alphabetic? "abc" 0 0))
 
 ;; 错误处理
-(check-catch 'wrong-type-arg (string-every 1 "012345"))
-(check-catch 'wrong-type-arg (string-every "012345" "012345"))
+(check-catch 'type-error (string-every 1 "012345"))
+(check-catch 'type-error (string-every "012345" "012345"))
 (check-catch 'out-of-range (string-every char-numeric? "ab234f" 2 7))
 (check-catch 'out-of-range (string-every char-numeric? "ab234f" 2 1))
 

--- a/tests/liii/string/string-index-right-test.scm
+++ b/tests/liii/string/string-index-right-test.scm
@@ -53,7 +53,7 @@
 ;; 错误处理
 ;; ----
 ;; wrong-type-arg 当str不是字符串类型时
-;; wrong-type-arg 当char/pred?不是字符或谓词时
+;; type-error 当char/pred?不是字符或谓词时
 ;; out-of-range 当start/end超出字符串索引范围时
 
 ;;
@@ -136,9 +136,9 @@
 (check (string-index-right "abcABC" char-upper-case?) => 5)
 
 (check-catch 'wrong-type-arg (string-index-right 123 #\a))
-(check-catch 'wrong-type-arg (string-index-right "hello" "a"))
-(check-catch 'wrong-type-arg (string-index-right "hello" 123))
-(check-catch 'wrong-type-arg (string-index-right "hello" '(a)))
+(check-catch 'type-error (string-index-right "hello" "a"))
+(check-catch 'type-error (string-index-right "hello" 123))
+(check-catch 'type-error (string-index-right "hello" '(a)))
 (check-catch 'out-of-range (string-index-right "hello" #\a -1))
 (check-catch 'out-of-range (string-index-right "hello" #\a 0 6))
 (check-catch 'out-of-range (string-index-right "hello" #\a 3 2))

--- a/tests/liii/string/string-index-test.scm
+++ b/tests/liii/string/string-index-test.scm
@@ -52,7 +52,7 @@
 ;; 错误处理
 ;; ----
 ;; wrong-type-arg 当str不是字符串类型时
-;; wrong-type-arg 当char/pred?不是字符或谓词时
+;; type-error 当char/pred?不是字符或谓词时
 ;; out-of-range 当start/end超出字符串索引范围时
 
 ;;
@@ -139,9 +139,9 @@
 (check (string-index "12345" char-alphabetic?) => #f)
 
 (check-catch 'wrong-type-arg (string-index 123 #\a))
-(check-catch 'wrong-type-arg (string-index "hello" "a"))
-(check-catch 'wrong-type-arg (string-index "hello" 123))
-(check-catch 'wrong-type-arg (string-index "hello" '(a)))
+(check-catch 'type-error (string-index "hello" "a"))
+(check-catch 'type-error (string-index "hello" 123))
+(check-catch 'type-error (string-index "hello" '(a)))
 (check-catch 'out-of-range (string-index "hello" #\a -1))
 (check-catch 'out-of-range (string-index "hello" #\a 0 6))
 (check-catch 'out-of-range (string-index "hello" #\a 3 2))

--- a/tests/liii/string/string-pad-right-test.scm
+++ b/tests/liii/string/string-pad-right-test.scm
@@ -86,6 +86,5 @@
 (check (string-pad-right "123" 7 #\0) => "1230000")
 
 (check-catch 'out-of-range (string-pad-right "abc" -1))
-(check-catch 'type-error (apply string-pad-right (cons* "abc" 10 #\space 'bad)))
 
 (check-report)

--- a/tests/liii/string/string-pad-right-test.scm
+++ b/tests/liii/string/string-pad-right-test.scm
@@ -86,5 +86,6 @@
 (check (string-pad-right "123" 7 #\0) => "1230000")
 
 (check-catch 'out-of-range (string-pad-right "abc" -1))
+(check-catch 'type-error (apply string-pad-right (cons* "abc" 10 #\space 'bad)))
 
 (check-report)

--- a/tests/liii/string/string-pad-test.scm
+++ b/tests/liii/string/string-pad-test.scm
@@ -183,6 +183,5 @@
 
 (check-catch 'out-of-range (string-pad "abc" -1))
 (check-catch 'out-of-range (string-pad-right "abc" -1))
-(check-catch 'type-error (apply string-pad (cons* "abc" 10 #\space 'bad)))
 
 (check-report)

--- a/tests/liii/string/string-pad-test.scm
+++ b/tests/liii/string/string-pad-test.scm
@@ -183,5 +183,6 @@
 
 (check-catch 'out-of-range (string-pad "abc" -1))
 (check-catch 'out-of-range (string-pad-right "abc" -1))
+(check-catch 'type-error (apply string-pad (cons* "abc" 10 #\space 'bad)))
 
 (check-report)

--- a/tests/liii/string/string-skip-right-test.scm
+++ b/tests/liii/string/string-skip-right-test.scm
@@ -44,7 +44,7 @@
 ;; 错误处理
 ;; ----
 ;; wrong-type-arg 当str不是字符串类型时
-;; wrong-type-arg 当char/pred?不是字符或谓词时
+;; type-error 当char/pred?不是字符或谓词时
 ;; out-of-range 当start/end超出字符串索引范围时
 
 ;; 基本功能测试
@@ -128,9 +128,9 @@
 
 ;; 错误处理测试
 (check-catch 'wrong-type-arg (string-skip-right 123 #\a))
-(check-catch 'wrong-type-arg (string-skip-right "hello" "a"))
-(check-catch 'wrong-type-arg (string-skip-right "hello" 123))
-(check-catch 'wrong-type-arg (string-skip-right "hello" '(a)))
+(check-catch 'type-error (string-skip-right "hello" "a"))
+(check-catch 'type-error (string-skip-right "hello" 123))
+(check-catch 'type-error (string-skip-right "hello" '(a)))
 (check-catch 'out-of-range (string-skip-right "hello" #\a -1))
 (check-catch 'out-of-range (string-skip-right "hello" #\a 0 6))
 (check-catch 'out-of-range (string-skip-right "hello" #\a 3 2))

--- a/tests/liii/string/string-skip-test.scm
+++ b/tests/liii/string/string-skip-test.scm
@@ -44,7 +44,7 @@
 ;; 错误处理
 ;; ----
 ;; wrong-type-arg 当str不是字符串类型时
-;; wrong-type-arg 当char/pred?不是字符或谓词时
+;; type-error 当char/pred?不是字符或谓词时
 ;; out-of-range 当start/end超出字符串索引范围时
 
 ;; 基本功能测试
@@ -128,9 +128,9 @@
 
 ;; 错误处理测试
 (check-catch 'wrong-type-arg (string-skip 123 #\a))
-(check-catch 'wrong-type-arg (string-skip "hello" "a"))
-(check-catch 'wrong-type-arg (string-skip "hello" 123))
-(check-catch 'wrong-type-arg (string-skip "hello" '(a)))
+(check-catch 'type-error (string-skip "hello" "a"))
+(check-catch 'type-error (string-skip "hello" 123))
+(check-catch 'type-error (string-skip "hello" '(a)))
 (check-catch 'out-of-range (string-skip "hello" #\a -1))
 (check-catch 'out-of-range (string-skip "hello" #\a 0 6))
 (check-catch 'out-of-range (string-skip "hello" #\a 3 2))

--- a/tests/liii/string/string-tokenize-test.scm
+++ b/tests/liii/string/string-tokenize-test.scm
@@ -120,7 +120,7 @@
 ) ;check
 
 (check-catch 'wrong-type-arg (string-tokenize 123))
-(check-catch 'wrong-type-arg (string-tokenize "hello" "not-a-char"))
+(check-catch 'type-error (string-tokenize "hello" "not-a-char"))
 (check-catch 'wrong-type-arg (string-tokenize "hello" #\h 1.5))
 (check-catch 'out-of-range (string-tokenize "hello" #\space -1))
 (check-catch 'out-of-range (string-tokenize "hello" #\space 0 10))
@@ -140,7 +140,5 @@
   =>
   '("2024" "08" "07")
 ) ;check
-
-(check-catch 'type-error (apply string-tokenize (cons* "hello" #\space 'bad)))
 
 (check-report)

--- a/tests/liii/string/string-tokenize-test.scm
+++ b/tests/liii/string/string-tokenize-test.scm
@@ -141,4 +141,6 @@
   '("2024" "08" "07")
 ) ;check
 
+(check-catch 'type-error (apply string-tokenize (cons* "hello" #\space 'bad)))
+
 (check-report)

--- a/tests/scheme/base/floor-quotient-test.scm
+++ b/tests/scheme/base/floor-quotient-test.scm
@@ -68,6 +68,6 @@
 (check (receive (q r) (floor/ 0 5) r) => 0)
 (check-catch 'division-by-zero (floor/ 11 0))
 (check-catch 'division-by-zero (floor/ 0 0))
-(check-catch 'wrong-type-arg (floor/ 1.0+1.0i 2))
-(check-catch 'wrong-type-arg (floor/ 5 #t))
+(check-catch 'type-error (floor/ 1.0+1.0i 2))
+(check-catch 'type-error (floor/ 5 #t))
 (check-report)

--- a/tests/scheme/base/floor-slash-test.scm
+++ b/tests/scheme/base/floor-slash-test.scm
@@ -38,6 +38,6 @@
 (check (list (floor/ 1 5)) => (list 0 1))
 ;; 错误测试
 (check-catch 'division-by-zero (floor/ 10 0))
-(check-catch 'wrong-type-arg (floor/ "10" 5))
-(check-catch 'wrong-type-arg (floor/ 10 "5"))
+(check-catch 'type-error (floor/ "10" 5))
+(check-catch 'type-error (floor/ 10 "5"))
 (check-report)

--- a/tests/scheme/base/truncate-slash-test.scm
+++ b/tests/scheme/base/truncate-slash-test.scm
@@ -34,6 +34,6 @@
 (check (receive (q r) (truncate/ 0 5) r) => 0)
 (check-catch 'division-by-zero (truncate/ 11 0))
 (check-catch 'division-by-zero (truncate/ 0 0))
-(check-catch 'wrong-type-arg (truncate/ 1.0+1.0i 2))
-(check-catch 'wrong-type-arg (truncate/ 5 #t))
+(check-catch 'type-error (truncate/ 1.0+1.0i 2))
+(check-catch 'type-error (truncate/ 5 #t))
 (check-report)

--- a/tests/srfi/srfi-117-test.scm
+++ b/tests/srfi/srfi-117-test.scm
@@ -1,0 +1,51 @@
+(import (liii check) (srfi srfi-117))
+
+(check-set-mode! 'report-failed)
+
+;; 基础构造与判断
+
+(define q1 (make-list-queue '(1 2 3)))
+(check-true (list-queue? q1))
+(check-false (list-queue-empty? q1))
+(check (list-queue-list q1) => '(1 2 3))
+(check (list-queue-front q1) => 1)
+(check (list-queue-back q1) => 3)
+
+;; 空队列测试与类型错误捕获
+
+(define q-empty (make-list-queue '()))
+(check-true (list-queue? q-empty))
+(check-true (list-queue-empty? q-empty))
+(check (list-queue-list q-empty) => '())
+(check-catch 'type-error (list-queue-front q-empty))
+(check-catch 'type-error (list-queue-back q-empty))
+(check-catch 'type-error (list-queue-remove-front! q-empty))
+(check-catch 'type-error (list-queue-remove-back! q-empty))
+
+;; 添加与删除元素
+
+(define q2 (make-list-queue '()))
+(list-queue-add-front! q2 10)
+(check (list-queue-front q2) => 10)
+(check (list-queue-back q2) => 10)
+(list-queue-add-back! q2 20)
+(check (list-queue-front q2) => 10)
+(check (list-queue-back q2) => 20)
+(check (list-queue-remove-front! q2) => 10)
+(check (list-queue-front q2) => 20)
+(check (list-queue-remove-back! q2) => 20)
+(check-true (list-queue-empty? q2))
+
+;; list-queue 快捷构造与复制
+
+(define q3 (list-queue 'a 'b 'c))
+(check (list-queue-list q3) => '(a b c))
+
+(define q3-copy (list-queue-copy q3))
+(check (list-queue-list q3-copy) => '(a b c))
+
+;; list-queue-remove-all!
+(check (list-queue-remove-all! q3) => '(a b c))
+(check-true (list-queue-empty? q3))
+
+(check-report)

--- a/tests/srfi/srfi-13/string-prefix-p-test.scm
+++ b/tests/srfi/srfi-13/string-prefix-p-test.scm
@@ -94,11 +94,11 @@
 (check (string-prefix? "🙂" "🙂") => #t)
 (check (string-prefix? "a⚡b" "a⚡btest") => #t)
 
-(check-catch 'wrong-type-arg (string-prefix? 123 "hello"))
-(check-catch 'wrong-type-arg (string-prefix? "hello" 123))
-(check-catch 'wrong-type-arg (string-prefix? '(a b c) "hello"))
-(check-catch 'wrong-type-arg (string-prefix? "hello" #\c))
-(check-catch 'wrong-type-arg (string-prefix? "hello" 'symbol))
-(check-catch 'wrong-type-arg (string-prefix? '() "hello"))
+(check-catch 'type-error (string-prefix? 123 "hello"))
+(check-catch 'type-error (string-prefix? "hello" 123))
+(check-catch 'type-error (string-prefix? '(a b c) "hello"))
+(check-catch 'type-error (string-prefix? "hello" #\c))
+(check-catch 'type-error (string-prefix? "hello" 'symbol))
+(check-catch 'type-error (string-prefix? '() "hello"))
 
 (check-report)

--- a/tests/srfi/srfi-13/string-suffix-p-test.scm
+++ b/tests/srfi/srfi-13/string-suffix-p-test.scm
@@ -98,11 +98,11 @@
 (check (string-suffix? ".tmu" "report.tmu") => #t)
 (check (string-suffix? "backup.txt" "file.backup.txt") => #t)
 
-(check-catch 'wrong-type-arg (string-suffix? 123 "hello"))
-(check-catch 'wrong-type-arg (string-suffix? "hello" 123))
-(check-catch 'wrong-type-arg (string-suffix? '(a b c) "hello"))
-(check-catch 'wrong-type-arg (string-suffix? "hello" #\c))
-(check-catch 'wrong-type-arg (string-suffix? "hello" 'symbol))
-(check-catch 'wrong-type-arg (string-suffix? '() "hello"))
+(check-catch 'type-error (string-suffix? 123 "hello"))
+(check-catch 'type-error (string-suffix? "hello" 123))
+(check-catch 'type-error (string-suffix? '(a b c) "hello"))
+(check-catch 'type-error (string-suffix? "hello" #\c))
+(check-catch 'type-error (string-suffix? "hello" 'symbol))
+(check-catch 'type-error (string-suffix? '() "hello"))
 
 (check-report)

--- a/tests/srfi/srfi-215-test.scm
+++ b/tests/srfi/srfi-215-test.scm
@@ -65,9 +65,9 @@
 (check (string? (cdr (assq 'SYM *last-msg*))) => #t)
 
 ;; send-log 验证 severity 范围
-(check-catch 'wrong-type-arg (send-log -1 "bad"))
-(check-catch 'wrong-type-arg (send-log 8 "bad"))
-(check-catch 'wrong-type-arg (send-log INFO 123))
+(check-catch 'type-error (send-log -1 "bad"))
+(check-catch 'type-error (send-log 8 "bad"))
+(check-catch 'type-error (send-log INFO 123))
 
 ;; current-log-callback 为 #f 时静默丢弃
 (current-log-callback #f)


### PR DESCRIPTION
## 任务简述
规范化 Scheme 代码中的错误契约，将抛出的 `wrong-type-arg` 统一替换为 `type-error`。

## 主要工作
1. **测试驱动开发（分为两个 commit）**：
   - 第一个 Commit：添加与更新单元测试，断言预期捕获 `type-error`，包括新增 `tests/srfi/srfi-117-test.scm`、在 `tests/liii/logging-test.scm` 与 `tests/liii/case-test.scm` 中补充参数校验错误测试，并更新现存测试中的断言。
   - 第二个 Commit：修改 `goldfish/` 下相关模块实现，统一使用 `type-error`。
2. **涉及模块**：
   - `goldfish/scheme/base.scm` (`floor/`, `truncate/`)
   - `goldfish/srfi/srfi-13.scm`
   - `goldfish/srfi/srfi-27.scm`
   - `goldfish/srfi/srfi-117.scm`
   - `goldfish/srfi/srfi-215.scm` & `goldfish/liii/logging.scm`
   - `goldfish/liii/case.scm`
   - `goldfish/liii/packrat.scm`
3. **保留项**：
   - 保留 `goldfish/liii/error.scm` 中 `type-error?` 谓词对底层原生 `wrong-type-arg` 的兼容。
4. **测试**：
   - 格式化已通过 `bin/gf fmt`，全部相关测试通过。