### PR TITLE
[0178] (liii logging) 默认自动 flush 日志输出

### DIFF
--- a/devel/0178.md
+++ b/devel/0178.md
@@ -1,4 +1,4 @@
-# [0178] (liii logging) 默认自动 flush 日志输出
+# [0178] (liii logging) 默认自动 flush 与开箱即用支持
 
 ## 任务相关的代码文件
 - goldfish/liii/logging.scm
@@ -11,6 +11,19 @@ xmake b goldfish
 bin/gf fmt
 bin/gf tests/liii/logging-test.scm
 ```
+
+## 2026-09-10 (liii logging) 对齐 Python 默认输出到 stderr 且默认级别为 WARNING
+
+### What
+1. 将 `*log-callback*` 初始值由静默空函数调整为 `(make-stderr-handler)`，未配置时开箱即可直接输出到 `(current-error-port)`。
+2. 将默认日志级别 `*log-level*` 由 `DEBUG` 调整为 `WARNING`，与 Python logging 默认行为完全一致。
+3. 更新 `send-log` 兜底分支输出目标为 `(current-error-port)`。
+4. 在 `tests/liii/logging-test.scm` 中增加开箱即用默认输出到 stderr 与默认级别过滤断言。
+
+### Why
+此前 `*log-callback*` 默认为空函数，导致未配置时日志被直接静默丢弃；且默认级别为 `DEBUG`。参考 Python logging 工业界标准规范：
+- 默认输出到 stderr 避免污染业务数据流与 stdout 管道；
+- 默认级别设为 `WARNING`，兼顾开发调试与运行时安静性。
 
 ## 2026-09-10 (liii logging) 默认在每条日志输出后自动 flush
 

--- a/devel/0178.md
+++ b/devel/0178.md
@@ -1,0 +1,28 @@
+# [0178] (liii logging) 默认自动 flush 日志输出
+
+## 任务相关的代码文件
+- goldfish/liii/logging.scm
+- tests/liii/logging-test.scm
+- devel/0178.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt
+bin/gf tests/liii/logging-test.scm
+```
+
+## 2026-09-10 (liii logging) 默认在每条日志输出后自动 flush
+
+### What
+1. 在 `default-log-handler`（控制台/端口输出）中，在输出换行符后调用 `(flush-output-port port)`。
+2. 在 `make-file-handler`（文件日志输出）中，在输出换行符后调用 `(flush-output-port port)`。
+3. 在 `tests/liii/logging-test.scm` 中增加测试用例，在文件输出端口未关闭时立即从文件读取内容，验证控制台默认处理器与文件处理器的即时 flush 行为。
+
+### Why
+此前日志模块仅在程序正常退出时的 `*exit-hook*` 或用户手动调用 `(log-flush!)` 时才 flush 端口。由于标准 I/O 缓冲机制，未 flush 时可能存在以下问题：
+- 在后台或终端通过 `tail -f` 无法实时看到最新写入的日志；
+- 进程异常退出、崩溃或被强制终止时，缓冲区中的最后几条关键日志丢失；
+- 在 REPL 环境中交互式调试体验不佳。
+
+借鉴 Python `logging` 的标准实现（`StreamHandler.emit()` 每次写完立即 flush），默认在每条日志写出后自动执行 `flush-output-port`。

--- a/goldfish/liii/logging.scm
+++ b/goldfish/liii/logging.scm
@@ -68,8 +68,7 @@
 
     ;; 内部状态变量
     (define *log-fields* '())
-    (define *log-callback* (lambda (log-entry) (values)))
-    (define *log-level* DEBUG)
+    (define *log-level* WARNING)
     (define *log-format* "%(asctime)s [%(levelname)s] %(message)s")
     (define *log-file-port* #f)
 
@@ -155,14 +154,12 @@
               ) ;
           (if callback
             (callback `((SEVERITY . ,severity) (MESSAGE . ,message) ,@alist))
-            ;; 默认行为：ERROR 及以上到 stderr，其他到 stdout
-            (let ((port (if (<= severity ERROR) (current-error-port) (current-output-port))))
-              (default-log-handler `((SEVERITY . ,severity)
-                                     (MESSAGE . ,message)
-                                     ,@alist)
-                port
-              ) ;default-log-handler
-            ) ;let
+            ;; 默认行为：输出到 stderr
+            (default-log-handler `((SEVERITY . ,severity)
+                                   (MESSAGE . ,message)
+                                   ,@alist)
+              (current-error-port)
+            ) ;default-log-handler
           ) ;if
         ) ;let*
       ) ;when
@@ -282,6 +279,9 @@
     (define (make-stderr-handler)
       (lambda (msg) (default-log-handler msg (current-error-port)))
     ) ;define
+
+    ;; 默认回调：输出到 stderr
+    (define *log-callback* (make-stderr-handler))
 
     ;; ============== 文件处理器 ==============
     (define (make-file-handler path)

--- a/goldfish/liii/logging.scm
+++ b/goldfish/liii/logging.scm
@@ -270,6 +270,7 @@
             ) ;
         (display formatted port)
         (newline port)
+        (flush-output-port port)
       ) ;let*
     ) ;define
 
@@ -314,6 +315,7 @@
                 ) ;
             (display line port)
             (newline port)
+            (flush-output-port port)
           ) ;let*
         ) ;lambda
       ) ;let

--- a/tests/liii/logging-test.scm
+++ b/tests/liii/logging-test.scm
@@ -1,4 +1,8 @@
-(import (liii check) (liii string) (liii logging))
+(import (liii check)
+        (liii string)
+        (liii path)
+        (scheme file)
+        (liii logging))
 
 ;; (liii logging) 测试用例
 
@@ -110,6 +114,38 @@
 
 ;; 恢复默认回调
 (log-set-callback! (lambda (log-entry) (values)))
+
+;; default-log-handler 自动 flush 测试
+(let* ((test-log (path->string (path-join (path-temp-dir) "goldfish-test-default-handler.log")))
+       (p (open-output-file test-log "w")))
+  (default-log-handler '((SEVERITY . 6) (MESSAGE . "default handler flush")) p)
+  ;; 不关闭 p，直接另开 input-file 读取；若已自动 flush，应能立即读到内容
+  (let ((content (call-with-input-file test-log (lambda (in) (read-string 100 in)))))
+    (check (string-contains? content "default handler flush") => #t))
+  (close-output-port p)
+  (delete-file test-log))
+
+;; make-file-handler 自动 flush 测试
+(let* ((test-log (path->string (path-join (path-temp-dir) "goldfish-test-file-handler.log")))
+       (handler (make-file-handler test-log)))
+  ;; 写入一条日志（端口保持打开，未关闭，未手动调用 log-flush!）
+  (handler '((SEVERITY . 6) (MESSAGE . "file handler flush")))
+  ;; 立即读取验证内容已刷新到文件
+  (let ((content (call-with-input-file test-log (lambda (in) (read-string 100 in)))))
+    (check (string-contains? content "file handler flush") => #t)
+    (check (string-contains? content "INFO") => #t))
+  ;; 清理
+  (log-set-callback! (lambda (msg) (values)))
+  (delete-file test-log))
+
+;; log-info 配合 log-set-file-handler! 自动 flush 测试
+(let ((test-log (path->string (path-join (path-temp-dir) "goldfish-test-set-file.log"))))
+  (log-set-file-handler! test-log)
+  (log-info "auto flush from log-info")
+  (let ((content (call-with-input-file test-log (lambda (in) (read-string 100 in)))))
+    (check (string-contains? content "auto flush from log-info") => #t))
+  (log-set-callback! (lambda (msg) (values)))
+  (delete-file test-log))
 
 ;; send-log 参数类型错误测试
 (check-catch 'type-error (send-log -1 "bad"))

--- a/tests/liii/logging-test.scm
+++ b/tests/liii/logging-test.scm
@@ -26,6 +26,28 @@
 ;; current-log-callback 默认值是过程
 (check (procedure? (current-log-callback)) => #t)
 
+;; current-log-level 默认值为 WARNING (与 Python 对齐)
+(check (current-log-level) => WARNING)
+
+;; 未配置时默认输出到 stderr，且默认过滤 INFO、放行 WARNING
+(let* ((p (open-output-string))
+       (old-err (set-current-error-port p)))
+  ;; 默认级别 WARNING 下，log-info 应该被过滤
+  (log-info "this should be filtered")
+  ;; log-warning 应该默认输出到 stderr
+  (log-warning "default warning to stderr")
+  ;; 恢复 stderr
+  (set-current-error-port old-err)
+  (let ((output (get-output-string p)))
+    (check (string-contains? output "default warning to stderr") => #t)
+    (check (string-contains? output "WARNING") => #t)
+    (check (string-contains? output "this should be filtered") => #f)
+  ) ;let
+) ;let
+
+;; 设置为 DEBUG 级别测试各级别的发送与回调
+(log-set-level! DEBUG)
+
 ;; send-log 兼容 SRFI-215
 (set! *last-msg* #f)
 (log-set-callback! (lambda (msg) (set! *last-msg* msg)))
@@ -81,7 +103,7 @@
 (check (cdr (assq 'MESSAGE *last-msg*)) => "should pass filter")
 
 ;; 恢复默认级别
-(log-set-level! DEBUG)
+(log-set-level! WARNING)
 
 ;; current-log-format 默认值
 (check (string? (current-log-format)) => #t)
@@ -113,7 +135,7 @@
 (check (log-message-field '((SEVERITY . 3)) 'MISSING) => #f)
 
 ;; 恢复默认回调
-(log-set-callback! (lambda (log-entry) (values)))
+(log-set-callback! (make-stderr-handler))
 
 ;; default-log-handler 自动 flush 测试
 (let* ((test-log (path->string (path-join (path-temp-dir) "goldfish-test-default-handler.log")))
@@ -135,16 +157,16 @@
     (check (string-contains? content "file handler flush") => #t)
     (check (string-contains? content "INFO") => #t))
   ;; 清理
-  (log-set-callback! (lambda (msg) (values)))
+  (log-set-callback! (make-stderr-handler))
   (delete-file test-log))
 
-;; log-info 配合 log-set-file-handler! 自动 flush 测试
+;; log-warning 配合 log-set-file-handler! 自动 flush 测试
 (let ((test-log (path->string (path-join (path-temp-dir) "goldfish-test-set-file.log"))))
   (log-set-file-handler! test-log)
-  (log-info "auto flush from log-info")
+  (log-warning "auto flush from log-warning")
   (let ((content (call-with-input-file test-log (lambda (in) (read-string 100 in)))))
-    (check (string-contains? content "auto flush from log-info") => #t))
-  (log-set-callback! (lambda (msg) (values)))
+    (check (string-contains? content "auto flush from log-warning") => #t))
+  (log-set-callback! (make-stderr-handler))
   (delete-file test-log))
 
 ;; send-log 参数类型错误测试


### PR DESCRIPTION
# [0178] (liii logging) 默认自动 flush 与开箱即用支持

## 任务相关的代码文件
- goldfish/liii/logging.scm
- tests/liii/logging-test.scm
- devel/0178.md

## 如何测试
```bash
xmake b goldfish
bin/gf fmt
bin/gf tests/liii/logging-test.scm
```

## 2026-09-10 (liii logging) 对齐 Python 默认输出到 stderr 且默认级别为 WARNING

### What
1. 将 `*log-callback*` 初始值由静默空函数调整为 `(make-stderr-handler)`，未配置时开箱即可直接输出到 `(current-error-port)`。
2. 将默认日志级别 `*log-level*` 由 `DEBUG` 调整为 `WARNING`，与 Python logging 默认行为完全一致。
3. 更新 `send-log` 兜底分支输出目标为 `(current-error-port)`。
4. 在 `tests/liii/logging-test.scm` 中增加开箱即用默认输出到 stderr 与默认级别过滤断言。

### Why
此前 `*log-callback*` 默认为空函数，导致未配置时日志被直接静默丢弃；且默认级别为 `DEBUG`。参考 Python logging 工业界标准规范：
- 默认输出到 stderr 避免污染业务数据流与 stdout 管道；
- 默认级别设为 `WARNING`，兼顾开发调试与运行时安静性。

## 2026-09-10 (liii logging) 默认在每条日志输出后自动 flush

### What
1. 在 `default-log-handler`（控制台/端口输出）中，在输出换行符后调用 `(flush-output-port port)`。
2. 在 `make-file-handler`（文件日志输出）中，在输出换行符后调用 `(flush-output-port port)`。
3. 在 `tests/liii/logging-test.scm` 中增加测试用例，在文件输出端口未关闭时立即从文件读取内容，验证控制台默认处理器与文件处理器的即时 flush 行为。

### Why
此前日志模块仅在程序正常退出时的 `*exit-hook*` 或用户手动调用 `(log-flush!)` 时才 flush 端口。由于标准 I/O 缓冲机制，未 flush 时可能存在以下问题：
- 在后台或终端通过 `tail -f` 无法实时看到最新写入的日志；
- 进程异常退出、崩溃或被强制终止时，缓冲区中的最后几条关键日志丢失；
- 在 REPL 环境中交互式调试体验不佳。

借鉴 Python `logging` 的标准实现（`StreamHandler.emit()` 每次写完立即 flush），默认在每条日志写出后自动执行 `flush-output-port`。